### PR TITLE
Overlap H2D and D2H

### DIFF
--- a/csrc/README.md
+++ b/csrc/README.md
@@ -1,6 +1,18 @@
 # SpiralPipe C source
 
+## Setup
+```
+# UCX
+export PATH=/path/to/ucx/build/bin:${PATH}
+export LD_LIBRARY_PATH=/path/to/ucx/build/lib:${LD_LIBRARY_PATH}
+
+# MPI
+export PATH=/path/to/mpi/build/bin:${PATH}
+export LD_LIBRARY_PATH=/path/to/mpi/build/lib:${LD_LIBRARY_PATH}
+
+```
+
 ## Installation
 ```
-MPI_BUILD_DIR=/path/to/mpi/build/ pip install .
+MPI_BUILD_DIR=/path/to/mpi/build CUDA_BUILD_DIR=/path/to/cuda/build pip install .
 ```

--- a/csrc/setup.py
+++ b/csrc/setup.py
@@ -15,11 +15,13 @@ setup(
             include_dirs=[
                 srcpath / 'external/spdlog/include',
                 os.path.join(os.environ['MPI_BUILD_DIR'], 'include'),
+                os.path.join(os.environ['CUDA_BUILD_DIR'], 'include'),
             ],
             library_dirs=[
                 os.path.join(os.environ['MPI_BUILD_DIR'], 'lib'),
+                os.path.join(os.environ['CUDA_BUILD_DIR'], 'lib64'),
             ],
-            libraries=['mpi', 'mpi_cxx', 'rt', 'pthread', 'cuda', 'cudart'], # linker. -lmpi, -lmpi_cxx
+            libraries=['mpi', 'rt', 'pthread', 'cuda', 'cudart'], # linker. -lmpi
             extra_compile_args=['-g', '-fvisibility=hidden']),
     ],
     cmdclass={

--- a/csrc/spiral_helper/allocator.cpp
+++ b/csrc/spiral_helper/allocator.cpp
@@ -67,6 +67,9 @@ void SpiralCPUAllocator::lazy_init(uintptr_t base, size_t offset, size_t size, s
   size_ = size;
   align_ = align;
 
+  // pin allocator memory
+  CHECK_CUDA(cudaHostRegister((void*)(base_ + offset_), size_, cudaHostRegisterPortable));
+  
   Block* dummy_head = new Block(offset_, 0, nullptr, nullptr);
   Block* body = new Block(offset_, size_, nullptr, nullptr);
   Block* dummy_tail = new Block(offset_, 0, nullptr, nullptr);
@@ -89,6 +92,9 @@ void SpiralCPUAllocator::lazy_init(uintptr_t base, size_t offset, size_t size, s
 SpiralCPUAllocator::~SpiralCPUAllocator() {
   if (SpiralCPUAllocator::debug)
     spdlog::info("SpiralCPUAllocator::~SpiralCPUAllocator");
+
+  // unpin allocator memory
+  CHECK_CUDA(cudaHostUnregister((void*)(base_ + offset_)));
 
   // Delete all blocks
   Block* cur = headblock_;

--- a/csrc/spiral_helper/allocator.cpp
+++ b/csrc/spiral_helper/allocator.cpp
@@ -67,9 +67,6 @@ void SpiralCPUAllocator::lazy_init(uintptr_t base, size_t offset, size_t size, s
   size_ = size;
   align_ = align;
 
-  // pin allocator memory
-  CHECK_CUDA(cudaHostRegister((void*)(base_ + offset_), size_, cudaHostRegisterPortable));
-
   Block* dummy_head = new Block(offset_, 0, nullptr, nullptr);
   Block* body = new Block(offset_, size_, nullptr, nullptr);
   Block* dummy_tail = new Block(offset_, 0, nullptr, nullptr);
@@ -92,9 +89,6 @@ void SpiralCPUAllocator::lazy_init(uintptr_t base, size_t offset, size_t size, s
 SpiralCPUAllocator::~SpiralCPUAllocator() {
   if (SpiralCPUAllocator::debug)
     spdlog::info("SpiralCPUAllocator::~SpiralCPUAllocator");
-
-  // unpin allocator memory
-  CHECK_CUDA(cudaHostUnregister((void*)(base_ + offset_)));
 
   // Delete all blocks
   Block* cur = headblock_;

--- a/csrc/spiral_helper/comm.cpp
+++ b/csrc/spiral_helper/comm.cpp
@@ -142,8 +142,9 @@ private:
   
   int fd_;
   void* shared_ptr_ = nullptr;
-  uintptr_t* shared_ptrs_;        // shared_ptr_ virtual address of each mpi rank
-  size_t shared_memory_size_ = 0; // size > 0 indicates shmem initialized
+  uintptr_t* shared_ptrs_;                    // shared_ptr_ virtual address of each mpi rank
+  size_t shared_memory_size_ = 0;             // size > 0 indicates shmem initialized
+  std::vector<void*> additional_pinned_ptrs_; // additional pinned pointers, else than allocator buffer
 
   struct ParamDataInfo {
     int mpi_rank_;      // mpi rank of initializer of param data
@@ -242,9 +243,6 @@ Comm::Comm(std::vector<int> ranks, const bool init_shmem) {
   // Initialize param mapping tbl
   param_mapping_tbl_ = (ParamDataInfo*)shared_ptr_;
 
-  // Pin shared memory buffer
-  CHECK_CUDA(cudaHostRegister((void*)GetBase(comm_info_.mpi_rank_), kCpuBufferSize, cudaHostRegisterPortable));
-
   // Initialize allocator
   assert(allocator_ == nullptr); // allocator_ must be nullptr before first calling instance
   allocator_ = c10::SpiralCPUAllocator::instance(GetBase(comm_info_.mpi_rank_), kCpuBufferSize / comm_info_.intra_size_ * comm_info_.intra_rank_, kCpuBufferSize / comm_info_.intra_size_, sizeof(float)); // Shared memory is divided equally among host processes
@@ -272,8 +270,10 @@ Comm::~Comm() {
   // NOTE: since allocator is designed to be a singleton,
   // we do not need to delete it here.
 
-  // Unpin shared memory buffer
-  CHECK_CUDA(cudaHostUnregister((void*)GetBase(comm_info_.mpi_rank_)));
+  // Unpin additional pinned pointers
+  for (void* ptr : additional_pinned_ptrs_) {
+    CHECK_CUDA(cudaHostUnregister(ptr));
+  }
 
   // Free shared_ptrs_
   free(shared_ptrs_);
@@ -318,6 +318,15 @@ void Comm::RemapParamData(torch::Tensor& tensor, const unsigned int param_id, co
   std::ptrdiff_t offset = addr - GetBase(param_mapping_tbl_[param_id].mpi_rank_);
   void* srcptr = (void*)(GetBase(comm_info_.mpi_rank_) + offset);
   c10::DataPtr srcdataptr = { srcptr, srcptr, nullptr, at::Device(at::DeviceType::CPU) }; // disallow delete
+
+  // pin source ptr
+  cudaPointerAttributes attributes;
+  CHECK_CUDA(cudaPointerGetAttributes(&attributes, srcptr));
+  // NOTE (SpiralPipe) May require separate logic for different memory types (unregistered, host, device)
+  if (attributes.cudaMemoryType != cudaMemoryTypeManaged) {
+    CHECK_CUDA(cudaHostRegister(srcptr, param_mapping_tbl_[param_id].size_bytes_, cudaHostRegisterPortable));
+    additional_pinned_ptrs_.push_back(srcptr);
+  }
 
   // change tensor metadata
   c10::TensorImpl* tensor_impl = tensor.unsafeGetTensorImpl();

--- a/csrc/spiral_helper/comm.cpp
+++ b/csrc/spiral_helper/comm.cpp
@@ -17,11 +17,12 @@
 #include <sys/types.h>
 #include <cstddef>
 #include <pybind11/numpy.h>
+#include <cuda_runtime.h>
 
 const char* sharedMemoryName = "/thunder";
 
 // const size_t kCpuBufferSize = 1L << 38; // 256GB, per host
-const size_t kCpuBufferSize = 1L << 35; // 32GB, per host
+const size_t kCpuBufferSize = 1L << 37; // 128GB, per host
 const size_t kCpuBufferHeaderSize = 1L << 30; // 1GB, per host
 
 std::vector<std::string> GetHostnames(MPI_Comm comm) {
@@ -241,6 +242,9 @@ Comm::Comm(std::vector<int> ranks, const bool init_shmem) {
   // Initialize param mapping tbl
   param_mapping_tbl_ = (ParamDataInfo*)shared_ptr_;
 
+  // Pin shared memory buffer
+  CHECK_CUDA(cudaHostRegister((void*)GetBase(comm_info_.mpi_rank_), kCpuBufferSize, cudaHostRegisterPortable));
+
   // Initialize allocator
   assert(allocator_ == nullptr); // allocator_ must be nullptr before first calling instance
   allocator_ = c10::SpiralCPUAllocator::instance(GetBase(comm_info_.mpi_rank_), kCpuBufferSize / comm_info_.intra_size_ * comm_info_.intra_rank_, kCpuBufferSize / comm_info_.intra_size_, sizeof(float)); // Shared memory is divided equally among host processes
@@ -267,6 +271,9 @@ Comm::~Comm() {
 
   // NOTE: since allocator is designed to be a singleton,
   // we do not need to delete it here.
+
+  // Unpin shared memory buffer
+  CHECK_CUDA(cudaHostUnregister((void*)GetBase(comm_info_.mpi_rank_)));
 
   // Free shared_ptrs_
   free(shared_ptrs_);

--- a/megatron/spiral/__init__.py
+++ b/megatron/spiral/__init__.py
@@ -1,4 +1,8 @@
-from .initialize import SpiralBackend, get_thunder_group, get_thunder_cuda_manager
+from .initialize import (
+    SpiralBackend,
+    get_thunder_group,
+    get_thunder_cuda_manager,
+)
 from .init_context import SpiralInitContext, SpiralParamStatus
 from .wrapper_init_context import SpiralWrapperInitContext
 from .generic import ContextManagers

--- a/megatron/spiral/schedules.py
+++ b/megatron/spiral/schedules.py
@@ -161,6 +161,7 @@ def _post_wait_set_spiral_param_status(module, status: SpiralParamStatus):
 
 
 def _weight_update(optimizer, bwd_stage_id, event_query, args, timers):
+    torch.cuda.nvtx.range_push(f"opt b[{bwd_stage_id}]")
     if (
         get_thunder_cuda_manager().wait_event(event_query, sync=True)
         == -1
@@ -174,6 +175,7 @@ def _weight_update(optimizer, bwd_stage_id, event_query, args, timers):
     optimizer.step(args, get_timers())
     if timers is not None:
         timers('optimizer').stop()
+    torch.cuda.nvtx.range_pop()
 
 
 def forward_backward_pipelining_with_spiral_remap(
@@ -771,7 +773,6 @@ def forward_backward_pipelining_with_spiral_remap(
 
         # spiral stage optimizer
         if optimize_after_bwd_stage:
-            torch.cuda.nvtx.range_push(f"opt b[{bwd_stage_id}]")
             # NOTE (SpiralPipe) multi-processing (either python multiprocessing or torch multiprocessing) does not work since cuda ctx is not shared between processes. So, we use threading.
             _optimizer_thread_status = getattr(optimizer, "optimizer_thread_pool").submit(
                 _weight_update,
@@ -784,7 +785,6 @@ def forward_backward_pipelining_with_spiral_remap(
                 ),
             )
             optimizer_threads_status.append(_optimizer_thread_status)
-            torch.cuda.nvtx.range_pop()
 
         mpu.set_spiral_backward_virtual_rank(None)
     # end bwd
@@ -1319,7 +1319,6 @@ def forward_backward_pipelining_with_spiral(
 
         # spiral stage optimizer
         if optimize_after_bwd_stage:
-            torch.cuda.nvtx.range_push(f"opt b[{bwd_stage_id}]")
             # NOTE (SpiralPipe) multi-processing (either python multiprocessing or torch multiprocessing) does not work since cuda ctx is not shared between processes. So, we use threading.
             _optimizer_thread_status = getattr(optimizer, "optimizer_thread_pool").submit(
                 _weight_update,
@@ -1332,7 +1331,6 @@ def forward_backward_pipelining_with_spiral(
                 ),
             )
             optimizer_threads_status.append(_optimizer_thread_status)
-            torch.cuda.nvtx.range_pop()
 
         mpu.set_spiral_backward_virtual_rank(None)
     # end bwd

--- a/megatron/spiral/schedules.py
+++ b/megatron/spiral/schedules.py
@@ -2,7 +2,7 @@ import contextlib
 import warnings
 import nvtx
 import sys
-from typing import Callable, Iterator, List, Optional, Union, Tuple, Dict
+from typing import Callable, Iterator, List, Optional, Union, Tuple
 from enum import Enum
 from concurrent.futures import wait, as_completed
 

--- a/megatron/spiral/schedules.py
+++ b/megatron/spiral/schedules.py
@@ -2,7 +2,7 @@ import contextlib
 import warnings
 import nvtx
 import sys
-from typing import Callable, Iterator, List, Optional, Union, Tuple
+from typing import Callable, Iterator, List, Optional, Union, Tuple, Dict
 from enum import Enum
 from concurrent.futures import wait, as_completed
 
@@ -14,7 +14,7 @@ from megatron.core import mpu
 from megatron.core.enums import ModelType
 from megatron.core.utils import get_model_type, get_attr_wrapped_model
 from megatron.core.pipeline_parallel import forward_step, backward_step
-from megatron.spiral import get_thunder_cuda_manager
+from megatron.spiral.initialize import get_thunder_cuda_manager
 from megatron.spiral.debug import spiral_print
 import megatron.spiral.p2p_communication as spiral_p2p
 from megatron.spiral.init_context import SpiralParamStatus
@@ -390,19 +390,15 @@ def forward_backward_pipelining_with_spiral_remap(
     # Data structures for training
     forward_data_store = []
 
-    prefetch_event_queries = []
-    compute_event_queries = []
-    offload_event_queries = []
+    # Event dictionaries. Key is the event tag, thus an event necessarily requires it.
+    prefetch_event_queries = {}
+    compute_event_queries = {}
+    offload_event_queries = {}
 
-    prefetch_query = None
-    compute_query = None
-    offload_query = None
+    # Placeholders
     recv_handles = None
 
     """ Start training """
-
-    # TODO (SpiralPipe) below line is temporarily added to sync between minibatches. Remove after optimizer sync is implemented
-    # torch.distributed.barrier(group=mpu.get_pipeline_model_parallel_group())
 
     # nop pre-pipeline non-compute timesteps
     __num_pre_pipeline_non_compute_ts = mpu.get_pipeline_model_parallel_rank()
@@ -413,7 +409,7 @@ def forward_backward_pipelining_with_spiral_remap(
     # prefetch 1st fwd stage
     with torch.cuda.stream(get_thunder_cuda_manager().Stream("prefetch")):
         model[0].spiral_fetch(non_blocking=True)
-        prefetch_query = get_thunder_cuda_manager().Event(
+        prefetch_f0 = get_thunder_cuda_manager().Event(
             "prefetch",
             "compute",
             tag="prefetch:f0",
@@ -421,9 +417,9 @@ def forward_backward_pipelining_with_spiral_remap(
                 model[0], SpiralParamStatus.ACTIVE
             ),
         )
-        if get_thunder_cuda_manager().record_event(prefetch_query) == -1:
+        if get_thunder_cuda_manager().record_event(prefetch_f0) == -1:
             raise RuntimeError("record_event failed")
-        prefetch_event_queries.append(prefetch_query)
+        prefetch_event_queries[prefetch_f0.tag] = prefetch_f0
 
     # fwd
     for fwd_stage_id in range(mpu.get_spiral_forward_virtual_size()):
@@ -439,7 +435,7 @@ def forward_backward_pipelining_with_spiral_remap(
         with torch.cuda.stream(get_thunder_cuda_manager().Stream("prefetch")):
             if not fwd_stage_id == 0:
                 if (
-                    get_thunder_cuda_manager().wait_event(offload_event_queries.pop(0))
+                    get_thunder_cuda_manager().wait_event(offload_event_queries.pop(f"free:f{fwd_stage_id - 1}"))
                     == -1
                 ):
                     raise RuntimeError("wait_event failed")
@@ -450,12 +446,12 @@ def forward_backward_pipelining_with_spiral_remap(
                 and fwd_stage_id == mpu.get_spiral_forward_virtual_size() - 1
             ):
                 model[fwd_stage_id + 1].spiral_fetch(non_blocking=True)
-                tag = (
-                    "prefetch:" + f"f{fwd_stage_id + 1}"
+                tag = "prefetch:" + (
+                    f"f{fwd_stage_id + 1}"
                     if fwd_stage_id + 1 < mpu.get_spiral_forward_virtual_size()
                     else f"b{mpu.get_spiral_backward_virtual_size() - 1}"
                 )
-                prefetch_query = get_thunder_cuda_manager().Event(
+                prefetch_next = get_thunder_cuda_manager().Event(
                     "prefetch",
                     "compute",
                     tag=tag,
@@ -463,14 +459,14 @@ def forward_backward_pipelining_with_spiral_remap(
                         model[fwd_stage_id + 1], SpiralParamStatus.ACTIVE
                     ),
                 )
-                if get_thunder_cuda_manager().record_event(prefetch_query) == -1:
+                if get_thunder_cuda_manager().record_event(prefetch_next) == -1:
                     raise RuntimeError("record_event failed")
-                prefetch_event_queries.append(prefetch_query)
+                prefetch_event_queries[prefetch_next.tag] = prefetch_next
 
         # compute stream wait for prefetch current stage
         with torch.cuda.stream(get_thunder_cuda_manager().Stream("compute")):
             if (
-                get_thunder_cuda_manager().wait_event(prefetch_event_queries.pop(0))
+                get_thunder_cuda_manager().wait_event(prefetch_event_queries.pop(f"prefetch:f{fwd_stage_id}"))
                 == -1
             ):
                 raise RuntimeError("wait_event failed")
@@ -521,30 +517,29 @@ def forward_backward_pipelining_with_spiral_remap(
                         enable_autocast,
                     )
 
-                compute_query = get_thunder_cuda_manager().Event(
+                compute_microbatch = get_thunder_cuda_manager().Event(
                     "compute",
                     None,
                     tag=f"compute:f{fwd_stage_id}m{i}",
                 )
-                if get_thunder_cuda_manager().record_event(compute_query) == -1:
+                if get_thunder_cuda_manager().record_event(compute_microbatch) == -1:
                     raise RuntimeError("record_event failed")
-                compute_event_queries.append(compute_query)
+                compute_event_queries[compute_microbatch.tag] = compute_microbatch
 
                 if i == num_microbatches - 1:
                     # notify offload stream to act
-                    compute_query = get_thunder_cuda_manager().Event(
+                    compute_microbatches_end = get_thunder_cuda_manager().Event(
                         "compute", "offload", tag=f"compute:f{fwd_stage_id}end"
                     )
-                    if get_thunder_cuda_manager().record_event(compute_query) == -1:
+                    if get_thunder_cuda_manager().record_event(compute_microbatches_end) == -1:
                         raise RuntimeError("record_event failed")
-                    compute_event_queries.append(compute_query)
+                    compute_event_queries[compute_microbatches_end.tag] = compute_microbatches_end
 
             # send output tensor
             if (
-                get_thunder_cuda_manager().wait_event(compute_event_queries.pop(0))
+                get_thunder_cuda_manager().wait_event(compute_event_queries.pop(f"compute:f{fwd_stage_id}m{i}"))
                 == -1
             ):
-                # wait event with tag=f"compute:f{fwd_stage_id}m{i}"
                 raise RuntimeError("wait_event failed")
             if not mpu.is_pipeline_last_stage():
                 _ = spiral_p2p.send_output_tensor(
@@ -559,10 +554,9 @@ def forward_backward_pipelining_with_spiral_remap(
 
         with torch.cuda.stream(get_thunder_cuda_manager().Stream("offload")):
             if (
-                get_thunder_cuda_manager().wait_event(compute_event_queries.pop(0))
+                get_thunder_cuda_manager().wait_event(compute_event_queries.pop(f"compute:f{fwd_stage_id}end"))
                 == -1
             ):
-                # wait event with tag=f"compute:f{fwd_stage_id}end"
                 raise RuntimeError("wait_event failed")
 
             # free fwd stage
@@ -571,17 +565,17 @@ def forward_backward_pipelining_with_spiral_remap(
                 forward_only
                 and fwd_stage_id == mpu.get_spiral_forward_virtual_size() - 1
             ):
-                offload_query = get_thunder_cuda_manager().Event(
+                free_curr = get_thunder_cuda_manager().Event(
                     "offload",
                     "prefetch",
-                    tag=f"offload:f{fwd_stage_id}",
+                    tag=f"free:f{fwd_stage_id}",
                     post_wait_fn=lambda fwd_stage_id=fwd_stage_id: _post_wait_set_spiral_param_status(
                         model[fwd_stage_id], SpiralParamStatus.REMOTE
                     ),
                 )
-                if get_thunder_cuda_manager().record_event(offload_query) == -1:
+                if get_thunder_cuda_manager().record_event(free_curr) == -1:
                     raise RuntimeError("record_event failed")
-                offload_event_queries.append(offload_query)
+                offload_event_queries[free_curr.tag] = free_curr
 
         mpu.set_spiral_forward_virtual_rank(None)
 
@@ -607,14 +601,20 @@ def forward_backward_pipelining_with_spiral_remap(
         # prefetch next stage
         with torch.cuda.stream(get_thunder_cuda_manager().Stream("prefetch")):
             if (
-                get_thunder_cuda_manager().wait_event(offload_event_queries.pop(0))
+                get_thunder_cuda_manager().wait_event(
+                    offload_event_queries.pop(
+                        f"free:f{fwd_stage_id}"
+                        if bwd_stage_id == mpu.get_spiral_backward_virtual_size() - 1
+                        else f"free:b{bwd_stage_id + 1}"
+                    )
+                )
                 == -1
             ):
                 raise RuntimeError("wait_event failed")
 
             if not bwd_stage_id == 0:
                 model[-bwd_stage_id].spiral_fetch(non_blocking=True)
-                prefetch_query = get_thunder_cuda_manager().Event(
+                prefetch_next = get_thunder_cuda_manager().Event(
                     "prefetch",
                     "compute",
                     tag="prefetch:" + f"b{bwd_stage_id - 1}",
@@ -622,15 +622,15 @@ def forward_backward_pipelining_with_spiral_remap(
                         model[-bwd_stage_id], SpiralParamStatus.ACTIVE
                     ),
                 )
-                if get_thunder_cuda_manager().record_event(prefetch_query) == -1:
+                if get_thunder_cuda_manager().record_event(prefetch_next) == -1:
                     raise RuntimeError("record_event failed")
-                prefetch_event_queries.append(prefetch_query)
+                prefetch_event_queries[prefetch_next.tag] = prefetch_next
 
         # compute stream wait for prefetch current stage
         # NOTE: prefetch for last bwd stage is called in the fwd loop
         with torch.cuda.stream(get_thunder_cuda_manager().Stream("compute")):
             if (
-                get_thunder_cuda_manager().wait_event(prefetch_event_queries.pop(0))
+                get_thunder_cuda_manager().wait_event(prefetch_event_queries.pop(f"prefetch:b{bwd_stage_id}"))
                 == -1
             ):
                 raise RuntimeError("wait_event failed")
@@ -701,30 +701,29 @@ def forward_backward_pipelining_with_spiral_remap(
                     deallocate_pipeline_outputs,
                 )
 
-                compute_query = get_thunder_cuda_manager().Event(
+                compute_microbatch = get_thunder_cuda_manager().Event(
                     "compute",
                     None,
                     tag=f"compute:b{bwd_stage_id}m{i}",
                 )
-                if get_thunder_cuda_manager().record_event(compute_query) == -1:
+                if get_thunder_cuda_manager().record_event(compute_microbatch) == -1:
                     raise RuntimeError("record_event failed")
-                compute_event_queries.append(compute_query)
+                compute_event_queries[compute_microbatch.tag] = compute_microbatch
 
                 if i == num_microbatches - 1:
                     # notify offload stream to act
-                    compute_query = get_thunder_cuda_manager().Event(
+                    compute_microbatches_end = get_thunder_cuda_manager().Event(
                         "compute", "offload", tag=f"compute:b{bwd_stage_id}end"
                     )
-                    if get_thunder_cuda_manager().record_event(compute_query) == -1:
+                    if get_thunder_cuda_manager().record_event(compute_microbatches_end) == -1:
                         raise RuntimeError("record_event failed")
-                    compute_event_queries.append(compute_query)
+                    compute_event_queries[compute_microbatches_end.tag] = compute_microbatches_end
 
             # send input tensor grad
             if (
-                get_thunder_cuda_manager().wait_event(compute_event_queries.pop(0))
+                get_thunder_cuda_manager().wait_event(compute_event_queries.pop(f"compute:b{bwd_stage_id}m{i}"))
                 == -1
             ):
-                # wait event with tag=f"compute:b{bwd_stage_id}m{i}"
                 raise RuntimeError("wait_event failed")
             if not mpu.is_pipeline_first_stage():
                 _ = spiral_p2p.send_input_tensor_grad(
@@ -739,37 +738,36 @@ def forward_backward_pipelining_with_spiral_remap(
 
         with torch.cuda.stream(get_thunder_cuda_manager().Stream("offload")):
             if (
-                get_thunder_cuda_manager().wait_event(compute_event_queries.pop(0))
+                get_thunder_cuda_manager().wait_event(compute_event_queries.pop(f"compute:b{bwd_stage_id}end"))
                 == -1
             ):
-                # wait event with tag=f"compute:b{bwd_stage_id}end"
                 raise RuntimeError("wait_event failed")
-
-            # offload gradient
-            model[-bwd_stage_id - 1].spiral_offload_grad(non_blocking=True)
-            if optimize_after_bwd_stage:
-                offload_query = get_thunder_cuda_manager().Event(
-                    "offload",
-                    None,
-                    tag=f"optimizer:b{bwd_stage_id}"
-                )
-                if get_thunder_cuda_manager().record_event(offload_query) == -1:
-                    raise RuntimeError("record_event failed")
-                offload_event_queries.append(offload_query)
 
             # free bwd stage
             model[-bwd_stage_id - 1].spiral_free()
-            offload_query = get_thunder_cuda_manager().Event(
+            free_curr = get_thunder_cuda_manager().Event(
                 "offload",
                 None if bwd_stage_id == 0 else "prefetch",
-                tag=f"offload:b{bwd_stage_id}",
+                tag=f"free:b{bwd_stage_id}",
                 post_wait_fn=lambda bwd_stage_id=bwd_stage_id: _post_wait_set_spiral_param_status(
                     model[-bwd_stage_id - 1], SpiralParamStatus.REMOTE
                 ),
             )
-            if get_thunder_cuda_manager().record_event(offload_query) == -1:
+            if get_thunder_cuda_manager().record_event(free_curr) == -1:
                 raise RuntimeError("record_event failed")
-            offload_event_queries.append(offload_query)
+            offload_event_queries[free_curr.tag] = free_curr
+
+            # offload gradient
+            model[-bwd_stage_id - 1].spiral_offload_grad(non_blocking=True)
+            if optimize_after_bwd_stage:
+                offload_grad_curr = get_thunder_cuda_manager().Event(
+                    "offload",
+                    None,
+                    tag=f"optimizer:b{bwd_stage_id}"
+                )
+                if get_thunder_cuda_manager().record_event(offload_grad_curr) == -1:
+                    raise RuntimeError("record_event failed")
+                offload_event_queries[offload_grad_curr.tag] = offload_grad_curr
 
         # spiral stage optimizer
         if optimize_after_bwd_stage:
@@ -779,7 +777,7 @@ def forward_backward_pipelining_with_spiral_remap(
                 *(
                     optimizer,
                     bwd_stage_id,
-                    offload_event_queries.pop(0), # TODO (SpiralPipe) This is very error-prone, since here and prefetch stream both pops head from the offload event queries. Pop after querying with appropriate tag.
+                    offload_event_queries.pop(f"optimizer:b{bwd_stage_id}"),
                     get_args(),
                     timers,
                 ),
@@ -809,10 +807,9 @@ def forward_backward_pipelining_with_spiral_remap(
                 raise Exception(f"Optimizer thread raised an exception: {e}")
 
     if (
-        get_thunder_cuda_manager().wait_event(offload_event_queries.pop(0))
+        get_thunder_cuda_manager().wait_event(offload_event_queries.pop(f"free:b0"))
         == -1
     ):
-        # wait event with tag="offload:b0"
         raise RuntimeError("wait_event failed")
 
     _cleanup()
@@ -946,13 +943,12 @@ def forward_backward_pipelining_with_spiral(
     if not forward_only and recompute:
         _recompute_data_iterator = [[] for _ in range(len(data_iterator))]
 
-    prefetch_event_queries = []
-    compute_event_queries = []
-    offload_event_queries = []
+    # Event dictionaries. Key is the event tag, thus an event necessarily requires it.
+    prefetch_event_queries = {}
+    compute_event_queries = {}
+    offload_event_queries = {}
 
-    prefetch_query = None
-    compute_query = None
-    offload_query = None
+    # Placeholders
     recv_handles = None
 
     """ Start training """
@@ -960,7 +956,7 @@ def forward_backward_pipelining_with_spiral(
     # prefetch 1st fwd stage
     with torch.cuda.stream(get_thunder_cuda_manager().Stream("prefetch")):
         model[0].spiral_fetch(non_blocking=True)
-        prefetch_query = get_thunder_cuda_manager().Event(
+        prefetch_f0 = get_thunder_cuda_manager().Event(
             "prefetch",
             "compute",
             tag="prefetch:f0",
@@ -968,9 +964,9 @@ def forward_backward_pipelining_with_spiral(
                 model[0], SpiralParamStatus.ACTIVE
             ),
         )
-        if get_thunder_cuda_manager().record_event(prefetch_query) == -1:
+        if get_thunder_cuda_manager().record_event(prefetch_f0) == -1:
             raise RuntimeError("record_event failed")
-        prefetch_event_queries.append(prefetch_query)
+        prefetch_event_queries[prefetch_f0.tag] = prefetch_f0
 
     # fwd
     for fwd_stage_id in range(mpu.get_spiral_forward_virtual_size()):
@@ -986,7 +982,7 @@ def forward_backward_pipelining_with_spiral(
         with torch.cuda.stream(get_thunder_cuda_manager().Stream("prefetch")):
             if not fwd_stage_id == 0:
                 if (
-                    get_thunder_cuda_manager().wait_event(offload_event_queries.pop(0))
+                    get_thunder_cuda_manager().wait_event(offload_event_queries.pop(f"free:f{fwd_stage_id - 1}"))
                     == -1
                 ):
                     raise RuntimeError("wait_event failed")
@@ -995,7 +991,7 @@ def forward_backward_pipelining_with_spiral(
             if not fwd_stage_id == mpu.get_spiral_forward_virtual_size() - 1:
                 model[fwd_stage_id + 1].spiral_fetch(non_blocking=True)
                 tag = "prefetch:" + f"f{fwd_stage_id + 1}"
-                prefetch_query = get_thunder_cuda_manager().Event(
+                prefetch_next = get_thunder_cuda_manager().Event(
                     "prefetch",
                     "compute",
                     tag=tag,
@@ -1003,14 +999,14 @@ def forward_backward_pipelining_with_spiral(
                         model[fwd_stage_id + 1], SpiralParamStatus.ACTIVE
                     ),
                 )
-                if get_thunder_cuda_manager().record_event(prefetch_query) == -1:
+                if get_thunder_cuda_manager().record_event(prefetch_next) == -1:
                     raise RuntimeError("record_event failed")
-                prefetch_event_queries.append(prefetch_query)
+                prefetch_event_queries[prefetch_next.tag] = prefetch_next
 
         # compute stream wait for prefetch current stage
         with torch.cuda.stream(get_thunder_cuda_manager().Stream("compute")):
             if (
-                get_thunder_cuda_manager().wait_event(prefetch_event_queries.pop(0))
+                get_thunder_cuda_manager().wait_event(prefetch_event_queries.pop(f"prefetch:f{fwd_stage_id}"))
                 == -1
             ):
                 raise RuntimeError("wait_event failed")
@@ -1073,30 +1069,29 @@ def forward_backward_pipelining_with_spiral(
                     assert isinstance(output_tensor, torch.Tensor) and output_tensor.numel() == 1
                     losses.append(output_tensor)
 
-                compute_query = get_thunder_cuda_manager().Event(
+                compute_microbatch = get_thunder_cuda_manager().Event(
                     "compute",
                     None,
                     tag=f"compute:f{fwd_stage_id}m{i}",
                 )
-                if get_thunder_cuda_manager().record_event(compute_query) == -1:
+                if get_thunder_cuda_manager().record_event(compute_microbatch) == -1:
                     raise RuntimeError("record_event failed")
-                compute_event_queries.append(compute_query)
+                compute_event_queries[compute_microbatch.tag] = compute_microbatch
 
                 if i == num_microbatches - 1:
                     # notify offload stream to act
-                    compute_query = get_thunder_cuda_manager().Event(
+                    compute_microbatches_end = get_thunder_cuda_manager().Event(
                         "compute", "offload", tag=f"compute:f{fwd_stage_id}end"
                     )
-                    if get_thunder_cuda_manager().record_event(compute_query) == -1:
+                    if get_thunder_cuda_manager().record_event(compute_microbatches_end) == -1:
                         raise RuntimeError("record_event failed")
-                    compute_event_queries.append(compute_query)
+                    compute_event_queries[compute_microbatches_end.tag] = compute_microbatches_end
 
             # send output tensor
             if (
-                get_thunder_cuda_manager().wait_event(compute_event_queries.pop(0))
+                get_thunder_cuda_manager().wait_event(compute_event_queries.pop(f"compute:f{fwd_stage_id}m{i}"))
                 == -1
             ):
-                # wait event with tag=f"compute:f{fwd_stage_id}m{i}"
                 raise RuntimeError("wait_event failed")
             if not mpu.is_pipeline_last_stage():
                 _ = spiral_p2p.send_output_tensor(
@@ -1111,25 +1106,25 @@ def forward_backward_pipelining_with_spiral(
 
         with torch.cuda.stream(get_thunder_cuda_manager().Stream("offload")):
             if (
-                get_thunder_cuda_manager().wait_event(compute_event_queries.pop(0))
+                get_thunder_cuda_manager().wait_event(compute_event_queries.pop(f"compute:f{fwd_stage_id}end"))
                 == -1
             ):
-                # wait event with tag=f"compute:f{fwd_stage_id}end"
                 raise RuntimeError("wait_event failed")
             # skip free if processing last fwd stage, as it will be reused as last bwd stage
             if not fwd_stage_id == mpu.get_spiral_forward_virtual_size() - 1:
                 model[fwd_stage_id].spiral_free()
-                offload_query = get_thunder_cuda_manager().Event(
+                free_curr = get_thunder_cuda_manager().Event(
                     "offload",
                     "prefetch",
-                    tag=f"offload:f{fwd_stage_id}",
+                    tag=f"free:f{fwd_stage_id}",
                     post_wait_fn=lambda fwd_stage_id=fwd_stage_id: _post_wait_set_spiral_param_status(
                         model[fwd_stage_id], SpiralParamStatus.REMOTE
                     ),
                 )
-                if get_thunder_cuda_manager().record_event(offload_query) == -1:
+                if get_thunder_cuda_manager().record_event(free_curr) == -1:
                     raise RuntimeError("record_event failed")
-                offload_event_queries.append(offload_query)
+                offload_event_queries[free_curr.tag] = free_curr
+
         mpu.set_spiral_forward_virtual_rank(None)
 
     if forward_only:
@@ -1155,14 +1150,14 @@ def forward_backward_pipelining_with_spiral(
             # skip offload wait if processing last bwd stage, as last fwd stage doesn't free
             if not bwd_stage_id == mpu.get_spiral_backward_virtual_size() - 1:
                 if (
-                    get_thunder_cuda_manager().wait_event(offload_event_queries.pop(0))
+                    get_thunder_cuda_manager().wait_event(offload_event_queries.pop(f"free:b{bwd_stage_id + 1}"))
                     == -1
                 ):
                     raise RuntimeError("wait_event failed")
 
             if not bwd_stage_id == 0:
                 model[bwd_stage_id - 1].spiral_fetch(non_blocking=True)
-                prefetch_query = get_thunder_cuda_manager().Event(
+                prefetch_next = get_thunder_cuda_manager().Event(
                     "prefetch",
                     "compute",
                     tag="prefetch:" + f"b{bwd_stage_id - 1}",
@@ -1170,16 +1165,16 @@ def forward_backward_pipelining_with_spiral(
                         model[bwd_stage_id - 1], SpiralParamStatus.ACTIVE
                     ),
                 )
-                if get_thunder_cuda_manager().record_event(prefetch_query) == -1:
+                if get_thunder_cuda_manager().record_event(prefetch_next) == -1:
                     raise RuntimeError("record_event failed")
-                prefetch_event_queries.append(prefetch_query)
+                prefetch_event_queries[prefetch_next.tag] = prefetch_next
 
         # compute stream wait for prefetch current stage
         with torch.cuda.stream(get_thunder_cuda_manager().Stream("compute")):
             # skip prefetch wait if processing last bwd stage, as last bwd stage reuse last fwd stage
             if not bwd_stage_id == mpu.get_spiral_backward_virtual_size() - 1:
                 if (
-                    get_thunder_cuda_manager().wait_event(prefetch_event_queries.pop(0))
+                    get_thunder_cuda_manager().wait_event(prefetch_event_queries.pop(f"prefetch:b{bwd_stage_id}"))
                     == -1
                 ):
                     raise RuntimeError("wait_event failed")
@@ -1247,30 +1242,29 @@ def forward_backward_pipelining_with_spiral(
                     deallocate_pipeline_outputs,
                 )
 
-                compute_query = get_thunder_cuda_manager().Event(
+                compute_microbatch = get_thunder_cuda_manager().Event(
                     "compute",
                     None,
                     tag=f"compute:b{bwd_stage_id}m{i}",
                 )
-                if get_thunder_cuda_manager().record_event(compute_query) == -1:
+                if get_thunder_cuda_manager().record_event(compute_microbatch) == -1:
                     raise RuntimeError("record_event failed")
-                compute_event_queries.append(compute_query)
+                compute_event_queries[compute_microbatch.tag] = compute_microbatch
 
                 if i == num_microbatches - 1:
                     # notify offload stream to act
-                    compute_query = get_thunder_cuda_manager().Event(
+                    compute_microbatches_end = get_thunder_cuda_manager().Event(
                         "compute", "offload", tag=f"compute:b{bwd_stage_id}end"
                     )
-                    if get_thunder_cuda_manager().record_event(compute_query) == -1:
+                    if get_thunder_cuda_manager().record_event(compute_microbatches_end) == -1:
                         raise RuntimeError("record_event failed")
-                    compute_event_queries.append(compute_query)
+                    compute_event_queries[compute_microbatches_end.tag] = compute_microbatches_end
 
             # send input tensor grad
             if (
-                get_thunder_cuda_manager().wait_event(compute_event_queries.pop(0))
+                get_thunder_cuda_manager().wait_event(compute_event_queries.pop(f"compute:b{bwd_stage_id}m{i}"))
                 == -1
             ):
-                # wait event with tag=f"compute:b{bwd_stage_id}m{i}"
                 raise RuntimeError("wait_event failed")
             if not mpu.is_pipeline_first_stage():
                 _ = spiral_p2p.send_input_tensor_grad(
@@ -1285,37 +1279,36 @@ def forward_backward_pipelining_with_spiral(
 
         with torch.cuda.stream(get_thunder_cuda_manager().Stream("offload")):
             if (
-                get_thunder_cuda_manager().wait_event(compute_event_queries.pop(0))
+                get_thunder_cuda_manager().wait_event(compute_event_queries.pop(f"compute:b{bwd_stage_id}end"))
                 == -1
             ):
-                # wait event with tag=f"compute:b{bwd_stage_id}end"
                 raise RuntimeError("wait_event failed")
-
-            # offload gradient
-            model[bwd_stage_id].spiral_offload_grad(non_blocking=True)
-            if optimize_after_bwd_stage:
-                offload_query = get_thunder_cuda_manager().Event(
-                    "offload",
-                    None,
-                    tag=f"optimizer:b{bwd_stage_id}"
-                )
-                if get_thunder_cuda_manager().record_event(offload_query) == -1:
-                    raise RuntimeError("record_event failed")
-                offload_event_queries.append(offload_query)
 
             # free bwd stage
             model[bwd_stage_id].spiral_free()
-            offload_query = get_thunder_cuda_manager().Event(
+            free_curr = get_thunder_cuda_manager().Event(
                 "offload",
                 None if bwd_stage_id == 0 else "prefetch",
-                tag=f"offload:b{bwd_stage_id}",
+                tag=f"free:b{bwd_stage_id}",
                 post_wait_fn=lambda bwd_stage_id=bwd_stage_id: _post_wait_set_spiral_param_status(
                     model[bwd_stage_id], SpiralParamStatus.REMOTE
                 ),
             )
-            if get_thunder_cuda_manager().record_event(offload_query) == -1:
+            if get_thunder_cuda_manager().record_event(free_curr) == -1:
                 raise RuntimeError("record_event failed")
-            offload_event_queries.append(offload_query)
+            offload_event_queries[free_curr.tag] = free_curr
+
+            # offload gradient
+            model[bwd_stage_id].spiral_offload_grad(non_blocking=True)
+            if optimize_after_bwd_stage:
+                offload_grad_curr = get_thunder_cuda_manager().Event(
+                    "offload",
+                    None,
+                    tag=f"optimizer:b{bwd_stage_id}"
+                )
+                if get_thunder_cuda_manager().record_event(offload_grad_curr) == -1:
+                    raise RuntimeError("record_event failed")
+                offload_event_queries[offload_grad_curr.tag] = offload_grad_curr
 
         # spiral stage optimizer
         if optimize_after_bwd_stage:
@@ -1325,7 +1318,7 @@ def forward_backward_pipelining_with_spiral(
                 *(
                     optimizer,
                     bwd_stage_id,
-                    offload_event_queries.pop(0), # TODO (SpiralPipe) This is very error-prone, since here and prefetch stream both pops head from the offload event queries. Pop after querying with appropriate tag.
+                    offload_event_queries.pop(f"optimizer:b{bwd_stage_id}"),
                     get_args(),
                     timers,
                 ),
@@ -1344,10 +1337,9 @@ def forward_backward_pipelining_with_spiral(
                 raise Exception(f"Optimizer thread raised an exception: {e}")
 
     if (
-        get_thunder_cuda_manager().wait_event(offload_event_queries.pop(0))
+        get_thunder_cuda_manager().wait_event(offload_event_queries.pop(f"free:b0"))
         == -1
     ):
-        # wait event with tag="offload:b0"
         raise RuntimeError("wait_event failed")
 
     _cleanup()


### PR DESCRIPTION
## Description
In schedule, free should precede offload_grad. This is because the two ops share offload stream. Otherwise offload_grad < free makes next prefetch to stall behind offload_grad, which is not necessary. This issue has been both identified and resolved by following nsys reports:

Prev: 
<img width="158" alt="스크린샷 2024-03-12 오후 10 48 19" src="https://github.com/mcrl/Megatron-LM-mcrl/assets/52441827/10c7c11b-875e-4451-9685-349f33686054">
Now:
<img width="283" alt="스크린샷 2024-03-12 오후 10 48 41" src="https://github.com/mcrl/Megatron-LM-mcrl/assets/52441827/861516c4-96e3-4e89-a9f9-6b29cbdc64fc">

Also, there has been bug in pinning the shmem address space. Each process must explicitly call cudaHostRegister() to the "used" shmem addresses, which mainly includes its shmem buffer partition as well as the re-mapped address spaces. If not, part of the fetched parameters (bwd params) are recognized as pinned while part (fwd params -- the remapped ones on other process' shmem buffer partition) is not. This has been resolved by additionally saving the `additional_pinned_ptrs_` in comm.cpp and unregistering at dtor.