### PR TITLE
[BUGFIX] Safe cudaHostRegister & Safe shared memory deletion

### DIFF
--- a/csrc/spiral_helper/allocator.cpp
+++ b/csrc/spiral_helper/allocator.cpp
@@ -8,6 +8,7 @@
 #include <stdio.h>
 #include <cuda_runtime.h>
 #include "util.hpp"
+#include <unistd.h>
 
 inline bool is_aligned(uintptr_t ptr, size_t align) {
   return ptr % align == 0;
@@ -61,13 +62,14 @@ SpiralCPUAllocator* SpiralCPUAllocator::instance(uintptr_t base, size_t offset, 
 
 void SpiralCPUAllocator::lazy_init(uintptr_t base, size_t offset, size_t size, size_t align) {
   assert(is_aligned(base + offset, align));
-
+  assert(is_aligned(base + offset, getpagesize()));
   base_ = base;
   offset_ = offset;
   size_ = size;
   align_ = align;
 
   // pin allocator memory
+  spdlog::info("Pinning allocator memory at ptr = {} size = {}", (void*)(base_ + offset_), size_);
   CHECK_CUDA(cudaHostRegister((void*)(base_ + offset_), size_, cudaHostRegisterPortable));
   
   Block* dummy_head = new Block(offset_, 0, nullptr, nullptr);

--- a/csrc/spiral_helper/allocator.cpp
+++ b/csrc/spiral_helper/allocator.cpp
@@ -69,7 +69,6 @@ void SpiralCPUAllocator::lazy_init(uintptr_t base, size_t offset, size_t size, s
   align_ = align;
 
   // pin allocator memory
-  spdlog::info("Pinning allocator memory at ptr = {} size = {}", (void*)(base_ + offset_), size_);
   CHECK_CUDA(cudaHostRegister((void*)(base_ + offset_), size_, cudaHostRegisterPortable));
   
   Block* dummy_head = new Block(offset_, 0, nullptr, nullptr);

--- a/csrc/spiral_helper/comm.cpp
+++ b/csrc/spiral_helper/comm.cpp
@@ -19,10 +19,10 @@
 #include <pybind11/numpy.h>
 #include <cuda_runtime.h>
 
-const char* sharedMemoryName = "/thunder-jy"; // set differently
+const char* sharedMemoryName = "/thunder"; // set differently
 
-const size_t kCpuBufferSize = 1L << 38; // 256GB, per host
-// const size_t kCpuBufferSize = 1L << 37; // 128GB, per host
+// const size_t kCpuBufferSize = 1L << 38; // 256GB, per host
+const size_t kCpuBufferSize = 1L << 36; // 32GB, per host
 const size_t kCpuBufferHeaderSize = 1L << 30; // 1GB, per host
 
 std::vector<std::string> GetHostnames(MPI_Comm comm) {
@@ -196,7 +196,9 @@ Comm::Comm(std::vector<int> ranks, const bool init_shmem) {
 
   // Open shared memory
   if (comm_info_.is_host_leader_) {
-    fd_ = shm_open(sharedMemoryName, O_CREAT | O_RDWR, S_IRUSR | S_IWUSR);
+    // O_EXCL to ensure a fresh shared memory creation on every exection.
+    // Error indicates that shared memory from previous execition has not been cleaned up properly.
+    fd_ = shm_open(sharedMemoryName, O_CREAT | O_EXCL | O_RDWR, S_IRUSR | S_IWUSR);
     assert(fd_ != -1);
     CHECK_ERRNO(ftruncate(fd_, shared_memory_size_));
 
@@ -319,16 +321,17 @@ void Comm::RemapParamData(torch::Tensor& tensor, const unsigned int param_id, co
   void* srcptr = (void*)(GetBase(comm_info_.mpi_rank_) + offset);
   c10::DataPtr srcdataptr = { srcptr, srcptr, nullptr, at::Device(at::DeviceType::CPU) }; // disallow delete
 
-  // pin source ptr  
-
+  // pin srcptr if not already pinned 
   cudaPointerAttributes attributes;
   CHECK_CUDA(cudaPointerGetAttributes(&attributes, srcptr));
-  // NOTE (SpiralPipe) May require separate logic for different memory types (unregistered, host, device)
-
-  bool is_mine = (comm_info_.mpi_rank_ == param_mapping_tbl_[param_id].mpi_rank_);
-  spdlog::info("attribute.type = {} is_mine = {}", attributes.type, is_mine);
-  if (attributes.type != cudaMemoryTypeManaged) {
-    CHECK_CUDA(cudaHostRegister(srcptr, param_mapping_tbl_[param_id].size_bytes_, cudaHostRegisterPortable));
+  bool is_assigned_bwd_param = (comm_info_.mpi_rank_ == param_mapping_tbl_[param_id].mpi_rank_);
+  if (is_assigned_bwd_param) {
+    assert(attributes.type == cudaMemoryTypeHost); // assert already pinned
+    // skip pin for assigned bwd param
+  } else {
+    assert(attributes.type == cudaMemoryTypeUnregistered);
+    // pin as readonly for remapped fwd param
+    CHECK_CUDA(cudaHostRegister(srcptr, param_mapping_tbl_[param_id].size_bytes_, cudaHostRegisterReadOnly));
     additional_pinned_ptrs_.push_back(srcptr);
   }
 

--- a/csrc/spiral_helper/comm.cpp
+++ b/csrc/spiral_helper/comm.cpp
@@ -19,10 +19,10 @@
 #include <pybind11/numpy.h>
 #include <cuda_runtime.h>
 
-const char* sharedMemoryName = "/thunder"; // set differently
+const char* sharedMemoryName = "/thunder-jy"; // set differently
 
-// const size_t kCpuBufferSize = 1L << 38; // 256GB, per host
-const size_t kCpuBufferSize = 1L << 37; // 128GB, per host
+const size_t kCpuBufferSize = 1L << 38; // 256GB, per host
+// const size_t kCpuBufferSize = 1L << 37; // 128GB, per host
 const size_t kCpuBufferHeaderSize = 1L << 30; // 1GB, per host
 
 std::vector<std::string> GetHostnames(MPI_Comm comm) {
@@ -319,10 +319,14 @@ void Comm::RemapParamData(torch::Tensor& tensor, const unsigned int param_id, co
   void* srcptr = (void*)(GetBase(comm_info_.mpi_rank_) + offset);
   c10::DataPtr srcdataptr = { srcptr, srcptr, nullptr, at::Device(at::DeviceType::CPU) }; // disallow delete
 
-  // pin source ptr
+  // pin source ptr  
+
   cudaPointerAttributes attributes;
   CHECK_CUDA(cudaPointerGetAttributes(&attributes, srcptr));
   // NOTE (SpiralPipe) May require separate logic for different memory types (unregistered, host, device)
+
+  bool is_mine = (comm_info_.mpi_rank_ == param_mapping_tbl_[param_id].mpi_rank_);
+  spdlog::info("attribute.type = {} is_mine = {}", attributes.type, is_mine);
   if (attributes.type != cudaMemoryTypeManaged) {
     CHECK_CUDA(cudaHostRegister(srcptr, param_mapping_tbl_[param_id].size_bytes_, cudaHostRegisterPortable));
     additional_pinned_ptrs_.push_back(srcptr);

--- a/csrc/spiral_helper/comm.cpp
+++ b/csrc/spiral_helper/comm.cpp
@@ -22,7 +22,7 @@
 const char* sharedMemoryName = "/thunder"; // set differently
 
 // const size_t kCpuBufferSize = 1L << 38; // 256GB, per host
-const size_t kCpuBufferSize = 1L << 36; // 32GB, per host
+const size_t kCpuBufferSize = 1L << 37; // 128GB, per host
 const size_t kCpuBufferHeaderSize = 1L << 30; // 1GB, per host
 
 std::vector<std::string> GetHostnames(MPI_Comm comm) {

--- a/megatron/spiral/initialize.py
+++ b/megatron/spiral/initialize.py
@@ -1,32 +1,41 @@
 from typing import Optional, Union, Tuple
 from collections import deque
 from dataclasses import dataclass
+import atexit
 
 import torch
 
 import spiral_helper
 
-global thunder_group
-global thunder_cuda_manager
+SPIRAL_BACKEND = None
 
 
 class SpiralBackend:
     def __init__(self, ranks, init_shmem):
-        global thunder_group
-        thunder_group = spiral_helper.Comm(sorted(ranks), init_shmem)
+        self.thunder_group = spiral_helper.Comm(sorted(ranks), init_shmem)
+        self.thunder_cuda_manager = SpiralCUDAManager()
+        global SPIRAL_BACKEND
+        SPIRAL_BACKEND = self
 
-        global thunder_cuda_manager
-        thunder_cuda_manager = SpiralCUDAManager()
+        # NOTE (SpiralPipe) Below enforces invocation of destructor for all objects in SpiralBackend when the program exits, either normally or abnormally. This is especially critical for spiral_helper.Comm, which allocates a hugh shared memory.
+        atexit.register(self.__del__)
+
+    def __del__(self):
+        global SPIRAL_BACKEND
+        if SPIRAL_BACKEND is not None:
+            SPIRAL_BACKEND = None
 
 
 def get_thunder_group():
-    assert thunder_group is not None, "thunder_group is not initialized"
-    return thunder_group
+    global SPIRAL_BACKEND
+    assert SPIRAL_BACKEND is not None, "SpiralBackend is not initialized"
+    return SPIRAL_BACKEND.thunder_group
 
 
 def get_thunder_cuda_manager():
-    assert thunder_cuda_manager is not None, "thunder_cuda_manager is not initialized"
-    return thunder_cuda_manager
+    global SPIRAL_BACKEND
+    assert SPIRAL_BACKEND is not None, "SpiralBackend is not initialized"
+    return SPIRAL_BACKEND.thunder_cuda_manager
 
 
 @dataclass(frozen=True)

--- a/megatron/training.py
+++ b/megatron/training.py
@@ -8,6 +8,7 @@ import sys
 import time
 import warnings
 import numpy as np
+
 # The earliest we can measure the start time.
 _TRAIN_START_TIME = time.time()
 import torch
@@ -42,11 +43,21 @@ from megatron.utils import calc_params_l2_norm
 from megatron.core.pipeline_parallel import get_forward_backward_func
 from megatron.utils import report_memory
 
-from megatron.spiral import get_thunder_group, SpiralInitContext, SpiralWrapperInitContext, ContextManagers
+from megatron.spiral import (
+    get_thunder_group,
+    SpiralInitContext,
+    SpiralWrapperInitContext,
+    ContextManagers,
+)
 import megatron.spiral.build_state as sbs
 from megatron.spiral.module import SpiralPhaseList
 from megatron.spiral.utils import is_spiral_param
-from megatron.spiral.debug import spiral_print, debug_param2id_shape_status, debug_module2name_id
+from megatron.spiral.debug import (
+    spiral_print,
+    debug_param2id_shape_status,
+    debug_module2name_id,
+    debug_param2name_id,
+)
 from megatron.spiral.init_context import patch_extra_repr
 
 from megatron.model.vision.knn_monitor import compute_feature_bank
@@ -525,6 +536,12 @@ def get_model(model_provider_func, model_type=ModelType.encoder_or_decoder, wrap
             #             for param in phase_model.parameters(recurse=True):
             #                 if is_spiral_param(param):
             #                     spiral_print(debug_param2id_shape_status(param) + str(param.spiral_tensor.data))
+
+            # NOTE (SpiralPipe) Modify this assertion after multi-node support @DY
+            for stage_model in model:
+                for param in stage_model.parameters(recurse=True):
+                    if is_spiral_param(param):
+                        assert getattr(param, "spiral_tensor").is_pinned(), f"{debug_param2name_id(param)} is not pinned. This will change in multi-node setting, as the parameters allocated in the host will only be pinned"
 
         if mpu.is_spiral_remap():
             get_thunder_group().UnsetSpiralCPUAllocator()


### PR DESCRIPTION
## Description

There is currently a memory leak from not being able to call shm_unlink in ~Comm, when the program exits abnormally in Python. This PR fixes it by adding __del__ to SpiralBackend and enforcing safe destruction of Comm instance. As a result, opened shm file in /dev/shm is flushed after program exit. Also, some safety codes is added to ensure always fresh creation of shmem file, since shmem usage with duplicate shmem name as the other users' creation leads to error. 

Also, data storage of remapped spiral tensors should be pinned, but only as read-only. A parameter (which is already pinned in allocator) could be the target of remap, when least common multiplier of forward virtual size and backward virtual size is not one of the two (e.g., 6 for 2 and 3). So, a conditional logic is added in Remap function.