### PR TITLE
Script files working on slurm cluster

### DIFF
--- a/examples/asplos25/config.sh
+++ b/examples/asplos25/config.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+
+# Modify this file for custom configuration
+
+## conda
+source ~/anaconda3/etc/profile.d/conda.sh
+conda activate Megatron-cuda11.7
+
+# MPI
+MPIRUN=$(which mpirun)
+MPI_OPTIONS="-mca btl ^openib -mca pml ucx"
+GPUS_PER_NODE=4
+NP=$(( $GPUS_PER_NODE * $SLURM_JOB_NUM_NODES ))
+UNWRAPPED_NODELIST=$(scontrol show hostnames $SLURM_NODELIST) # b3 b4
+HOSTS=$(for node in $UNWRAPPED_NODELIST; do echo -n "$node:$GPUS_PER_NODE,"; done | sed 's/,$//') # b3:2,b4:2
+
+# Source code
+MEGATRON_PATH=$HOME/asplos2025/Megatron-LM-mcrl
+
+# nsys
+NSYS_ENABLE=NO
+NSYS=$(which nsys)
+NSYS_OUTPUT=${MEGATRON_PATH}/logs/${SLURM_JOB_ID}-${SLURM_JOB_NAME}
+
+# Data and tokenizer files
+DATA_PATH=/data/z0/heehoon/openwebtext-mg/openwebtext_text_document
+VOCAB_FILE=/home/n0/yujin/tmp/tokenizer/megatron/gpt2-vocab.json
+MERGE_FILE=/home/n0/yujin/tmp/tokenizer/megatron/gpt2-merges.txt
+
+# Model spec
+LAYER=24
+HIDDEN=1024
+HEAD=16
+
+# Micro Batch size
+MBS=1
+
+# iteration
+TRAIN_ITER=100
+LOG_ITER=10
+EVAL_ITER=0
+
+# config for spiral training
+SPIRAL_FWD=1
+SPIRAL_BWD=3
+SPIRAL_STAGED_OPTIMIZER=NO
+SPIRAL_DEBUG_BACKEND=NO
+
+# config for interleaving
+INTERLEAVE_VIRTUAL_SIZE=2
+
+# Print configuration
+echo -e "===========Script Configuration==========="
+echo -e "JOB_NAME=${SLURM_JOB_NAME}\nHOSTS=${HOSTS}\nNSYS_ENABLE=${NSYS_ENABLE}"
+echo -e "LAYER=${LAYER}\nHIDDEN=${HIDDEN}\nHEAD=${HEAD}\nMBS=${MBS}"
+echo -e "TRAIN_ITER=${TRAIN_ITER}\nLOG_ITER=${LOG_ITER}\nEVAL_ITER=${EVAL_ITER}"
+echo -e "SPIRAL_FWD=${SPIRAL_FWD}\nSPIRAL_BWD=${SPIRAL_BWD}"
+echo -e "SPIRAL_STAGED_OPTIMIZER=${SPIRAL_STAGED_OPTIMIZER}\nSPIRAL_DEBUG_BACKEND=${SPIRAL_DEBUG_BACKEND}"
+echo -e "INTERLEAVE_VIRTUAL_SIZE=${INTERLEAVE_VIRTUAL_SIZE}"
+echo "==========================================="

--- a/examples/asplos25/mpirun_pretrain_gpt_interleaving.sh
+++ b/examples/asplos25/mpirun_pretrain_gpt_interleaving.sh
@@ -1,82 +1,30 @@
 #!/bin/bash
 
-MPIRUN=/usr/local/bin/mpirun
-MPI_OPTIONS="-mca btl ^openib -mca pml ucx"
-MEGATRON_PATH=$HOME/asplos2025/Megatron-LM-mcrl
+#SBATCH -J interleaving
+#SBATCH --mincpus=4
+#SBATCH --mem=0
+#SBATCH --exclusive
 
-# Change for your system
+if [ -n "${SLURM_JOB_ID:-}" ] ; then
+    SCRIPT_PATH=$(scontrol show job "$SLURM_JOB_ID" | awk -F= '/Command=/{print $2}')
+else
+    SCRIPT_PATH=$(realpath "$0")
+fi
 
-## conda
-source ~/anaconda3/etc/profile.d/conda.sh
-conda activate Megatron-cuda11.7
+# Configuration for custom env
+. $(dirname "${SCRIPT_PATH}")/config.sh
 
-## mpi
-NP=4
-GPUS_PER_NODE=4
-HOSTS="b4:${GPUS_PER_NODE}" # b3:2,b4:2
-
-## torch dist.
-export MASTER_ADDR="b4"
-export MASTER_PORT=6003
-export CUDA_VISIBLE_DEVICES=0,1,2,3
-export CUDA_DEVICE_MAX_CONNECTIONS=1
-
-## Config file path
-MODEL_PATH=/home/n0/yujin/tmp/model/gpt-like-270m
-VOCAB_FILE=/home/n0/yujin/tmp/tokenizer/megatron/gpt2-vocab.json
-MERGE_FILE=/home/n0/yujin/tmp/tokenizer/megatron/gpt2-merges.txt
-
-DATASET_NAME=openwebtext
-DATASET_CONFIG=plan_text
-DATA_PATH=/data/z0/heehoon/openwebtext-mg/openwebtext_text_document
-
-SPIRAL_ARGS="
+# Configuration for mobius-recompute training
+EXTRA_ARGS="
+    --num-layers-per-virtual-pipeline-stage $(($LAYER/$NP/$INTERLEAVE_VIRTUAL_SIZE)) \
+    --recompute-granularity full \
+    --recompute-method uniform \
+    --recompute-num-layers $(($LAYER/$NP/$INTERLEAVE_VIRTUAL_SIZE)) \
+    --overlap-p2p-communication \
     --megatron-mpi
 "
 
-NUM_LAYERS=24
-VIRTUAL_SIZE=2
+# Run script
+. $(dirname "${SCRIPT_PATH}")/run.sh
 
-GPT_ARGS="
-    --tensor-model-parallel-size 1 \
-    --pipeline-model-parallel-size $NP \
-    --num-layers-per-virtual-pipeline-stage $(($NUM_LAYERS/$NP/$VIRTUAL_SIZE)) \
-    --recompute-granularity full \
-    --recompute-method uniform \
-    --recompute-num-layers 1 \
-    --no-initialization \
-    --untie-embeddings-and-output-weights \
-    --distributed-backend nccl \
-    --overlap-p2p-communication \
-    --sequence-parallel \
-    --num-layers $NUM_LAYERS \
-    --hidden-size 1024 \
-    --num-attention-heads 16 \
-    --seq-length 1024 \
-    --max-position-embeddings 1024 \
-    --micro-batch-size 1 \
-    --global-batch-size 4 \
-    --lr 0.00015 \
-    --train-iters 3 \
-    --eval-iters 0 \
-    --lr-decay-iters 320000 \
-    --lr-decay-style cosine \
-    --min-lr 1.0e-5 \
-    --weight-decay 1e-2 \
-    --lr-warmup-fraction .01 \
-    --clip-grad 0.0 \
-    --attention-dropout 0.0 \
-    --hidden-dropout 0.0 \
-    --no-gradient-accumulation-fusion
-"
-
-DATA_ARGS="
-    --data-path $DATA_PATH \
-    --vocab-file $VOCAB_FILE \
-    --merge-file $MERGE_FILE \
-    --data-impl mmap \
-    --split 949,50,1
-"
-
-${MPIRUN} -np $NP -host $HOSTS $MPI_OPTIONS \
-    python $MEGATRON_PATH/pretrain_gpt.py $SPIRAL_ARGS $GPT_ARGS $DATA_ARGS --load $MODEL_PATH
+exit 0

--- a/examples/asplos25/mpirun_pretrain_gpt_mobius_no_recompute.sh
+++ b/examples/asplos25/mpirun_pretrain_gpt_mobius_no_recompute.sh
@@ -1,79 +1,37 @@
 #!/bin/bash
 
-MPIRUN=/usr/local/bin/mpirun
-MPI_OPTIONS="-mca btl ^openib -mca pml ucx"
-MEGATRON_PATH=$HOME/asplos2025/Megatron-LM-mcrl
+#SBATCH -J mobius-no-recompute
+#SBATCH --mincpus=4
+#SBATCH --mem=0
+#SBATCH --exclusive
 
-# Change for your system
+if [ -n "${SLURM_JOB_ID:-}" ] ; then
+    SCRIPT_PATH=$(scontrol show job "$SLURM_JOB_ID" | awk -F= '/Command=/{print $2}')
+else
+    SCRIPT_PATH=$(realpath "$0")
+fi
 
-## conda
-source ~/anaconda3/etc/profile.d/conda.sh
-conda activate Megatron-cuda11.7
+# Configuration for custom env
+. $(dirname "${SCRIPT_PATH}")/config.sh
 
-## mpi
-NP=4
-GPUS_PER_NODE=4
-HOSTS="b4:${GPUS_PER_NODE}" # b3:2,b4:2
-
-## torch dist.
-export MASTER_ADDR="b4"
-export MASTER_PORT=6003
-export CUDA_VISIBLE_DEVICES=0,1,2,3
-export CUDA_DEVICE_MAX_CONNECTIONS=1
-
-## Config file path
-MODEL_PATH=/home/n0/yujin/tmp/model/gpt-like-270m
-VOCAB_FILE=/home/n0/yujin/tmp/tokenizer/megatron/gpt2-vocab.json
-MERGE_FILE=/home/n0/yujin/tmp/tokenizer/megatron/gpt2-merges.txt
-
-DATASET_NAME=openwebtext
-DATASET_CONFIG=plan_text
-DATA_PATH=/data/z0/heehoon/openwebtext-mg/openwebtext_text_document
-
-# --spiral-stage-optimizer
-SPIRAL_ARGS="
+# Configuration for mobius-recompute training
+EXTRA_ARGS="
     --spiral \
-    --spiral-forward-virtual-size 2 \
-    --spiral-backward-virtual-size 2 \
+    --spiral-forward-virtual-size $SPIRAL_FWD \
+    --spiral-backward-virtual-size $SPIRAL_FWD \
+    --overlap-p2p-communication \
     --megatron-mpi
 "
 
-GPT_ARGS="
-    --tensor-model-parallel-size 1 \
-    --pipeline-model-parallel-size $NP \
-    --no-initialization \
-    --untie-embeddings-and-output-weights \
-    --distributed-backend nccl \
-    --overlap-p2p-communication \
-    --sequence-parallel \
-    --num-layers 24 \
-    --hidden-size 1024 \
-    --num-attention-heads 16 \
-    --seq-length 1024 \
-    --max-position-embeddings 1024 \
-    --micro-batch-size 1 \
-    --global-batch-size 4 \
-    --lr 0.00015 \
-    --train-iters 3 \
-    --eval-iters 0 \
-    --lr-decay-iters 320000 \
-    --lr-decay-style cosine \
-    --min-lr 1.0e-5 \
-    --weight-decay 1e-2 \
-    --lr-warmup-fraction .01 \
-    --clip-grad 0.0 \
-    --attention-dropout 0.0 \
-    --hidden-dropout 0.0 \
-    --no-gradient-accumulation-fusion
-"
+if [ ${SPIRAL_STAGED_OPTIMIZER} == "YES" ]; then
+    EXTRA_ARGS+=" --spiral-stage-optimizer"
+fi
 
-DATA_ARGS="
-    --data-path $DATA_PATH \
-    --vocab-file $VOCAB_FILE \
-    --merge-file $MERGE_FILE \
-    --data-impl mmap \
-    --split 949,50,1
-"
+if [ ${SPIRAL_DEBUG_BACKEND} == "YES" ]; then
+    EXTRA_ARGS+=" --spiral-debug-backend"
+fi
 
-${MPIRUN} -np $NP -host $HOSTS $MPI_OPTIONS \
-    python $MEGATRON_PATH/pretrain_gpt.py $SPIRAL_ARGS $GPT_ARGS $DATA_ARGS --load $MODEL_PATH
+# Run script
+. $(dirname "${SCRIPT_PATH}")/run.sh
+
+exit 0

--- a/examples/asplos25/mpirun_pretrain_gpt_mobius_recompute.sh
+++ b/examples/asplos25/mpirun_pretrain_gpt_mobius_recompute.sh
@@ -1,80 +1,38 @@
 #!/bin/bash
 
-MPIRUN=/usr/local/bin/mpirun
-MPI_OPTIONS="-mca btl ^openib -mca pml ucx"
-MEGATRON_PATH=$HOME/asplos2025/Megatron-LM-mcrl
+#SBATCH -J mobius-recompute
+#SBATCH --mincpus=4
+#SBATCH --mem=0
+#SBATCH --exclusive
 
-# Change for your system
+if [ -n "${SLURM_JOB_ID:-}" ] ; then
+    SCRIPT_PATH=$(scontrol show job "$SLURM_JOB_ID" | awk -F= '/Command=/{print $2}')
+else
+    SCRIPT_PATH=$(realpath "$0")
+fi
 
-## conda
-source ~/anaconda3/etc/profile.d/conda.sh
-conda activate Megatron-cuda11.7
+# Configuration for custom env
+. $(dirname "${SCRIPT_PATH}")/config.sh
 
-## mpi
-NP=4
-GPUS_PER_NODE=4
-HOSTS="b4:${GPUS_PER_NODE}" # b3:2,b4:2
-
-## torch dist.
-export MASTER_ADDR="b4"
-export MASTER_PORT=6003
-export CUDA_VISIBLE_DEVICES=0,1,2,3
-export CUDA_DEVICE_MAX_CONNECTIONS=1
-
-## Config file path
-MODEL_PATH=/home/n0/yujin/tmp/model/gpt-like-270m
-VOCAB_FILE=/home/n0/yujin/tmp/tokenizer/megatron/gpt2-vocab.json
-MERGE_FILE=/home/n0/yujin/tmp/tokenizer/megatron/gpt2-merges.txt
-
-DATASET_NAME=openwebtext
-DATASET_CONFIG=plan_text
-DATA_PATH=/data/z0/heehoon/openwebtext-mg/openwebtext_text_document
-
-# --spiral-stage-optimizer
-SPIRAL_ARGS="
+# Configuration for mobius-recompute training
+EXTRA_ARGS="
     --spiral \
-    --spiral-forward-virtual-size 2 \
-    --spiral-backward-virtual-size 2 \
+    --spiral-forward-virtual-size $SPIRAL_FWD \
+    --spiral-backward-virtual-size $SPIRAL_FWD \
     --spiral-recompute-activations \
+    --overlap-p2p-communication \
     --megatron-mpi
 "
 
-GPT_ARGS="
-    --tensor-model-parallel-size 1 \
-    --pipeline-model-parallel-size $NP \
-    --no-initialization \
-    --untie-embeddings-and-output-weights \
-    --distributed-backend nccl \
-    --overlap-p2p-communication \
-    --sequence-parallel \
-    --num-layers 24 \
-    --hidden-size 1024 \
-    --num-attention-heads 16 \
-    --seq-length 1024 \
-    --max-position-embeddings 1024 \
-    --micro-batch-size 1 \
-    --global-batch-size 4 \
-    --lr 0.00015 \
-    --train-iters 3 \
-    --eval-iters 0 \
-    --lr-decay-iters 320000 \
-    --lr-decay-style cosine \
-    --min-lr 1.0e-5 \
-    --weight-decay 1e-2 \
-    --lr-warmup-fraction .01 \
-    --clip-grad 0.0 \
-    --attention-dropout 0.0 \
-    --hidden-dropout 0.0 \
-    --no-gradient-accumulation-fusion
-"
+if [ ${SPIRAL_STAGED_OPTIMIZER} == "YES" ]; then
+    EXTRA_ARGS+=" --spiral-stage-optimizer"
+fi
 
-DATA_ARGS="
-    --data-path $DATA_PATH \
-    --vocab-file $VOCAB_FILE \
-    --merge-file $MERGE_FILE \
-    --data-impl mmap \
-    --split 949,50,1
-"
+if [ ${SPIRAL_DEBUG_BACKEND} == "YES" ]; then
+    EXTRA_ARGS+=" --spiral-debug-backend"
+fi
 
-${MPIRUN} -np $NP -host $HOSTS $MPI_OPTIONS \
-    python $MEGATRON_PATH/pretrain_gpt.py $SPIRAL_ARGS $GPT_ARGS $DATA_ARGS --load $MODEL_PATH
+# Run script
+. $(dirname "${SCRIPT_PATH}")/run.sh
+
+exit 0

--- a/examples/asplos25/mpirun_pretrain_gpt_no_interleaving.sh
+++ b/examples/asplos25/mpirun_pretrain_gpt_no_interleaving.sh
@@ -1,78 +1,28 @@
 #!/bin/bash
 
-MPIRUN=/usr/local/bin/mpirun
-MPI_OPTIONS="-mca btl ^openib -mca pml ucx"
-MEGATRON_PATH=$HOME/asplos2025/Megatron-LM-mcrl
+#SBATCH -J no-interleaving
+#SBATCH --mincpus=4
+#SBATCH --mem=0
+#SBATCH --exclusive
 
-# Change for your system
+if [ -n "${SLURM_JOB_ID:-}" ] ; then
+    SCRIPT_PATH=$(scontrol show job "$SLURM_JOB_ID" | awk -F= '/Command=/{print $2}')
+else
+    SCRIPT_PATH=$(realpath "$0")
+fi
 
-## conda
-source ~/anaconda3/etc/profile.d/conda.sh
-conda activate Megatron-cuda11.7
+# Configuration for custom env
+. $(dirname "${SCRIPT_PATH}")/config.sh
 
-## mpi
-NP=4
-GPUS_PER_NODE=4
-HOSTS="b4:${GPUS_PER_NODE}" # b3:2,b4:2
-
-## torch dist.
-export MASTER_ADDR="b4"
-export MASTER_PORT=6003
-export CUDA_VISIBLE_DEVICES=0,1,2,3
-export CUDA_DEVICE_MAX_CONNECTIONS=1
-
-## Config file path
-MODEL_PATH=/home/n0/yujin/tmp/model/gpt-like-270m
-VOCAB_FILE=/home/n0/yujin/tmp/tokenizer/megatron/gpt2-vocab.json
-MERGE_FILE=/home/n0/yujin/tmp/tokenizer/megatron/gpt2-merges.txt
-
-DATASET_NAME=openwebtext
-DATASET_CONFIG=plan_text
-DATA_PATH=/data/z0/heehoon/openwebtext-mg/openwebtext_text_document
-
-SPIRAL_ARGS="
+# Configuration for mobius-recompute training
+EXTRA_ARGS="
+    --recompute-granularity full \
+    --recompute-method uniform \
+    --recompute-num-layers $(($LAYER/$NP)) \
     --megatron-mpi
 "
 
-GPT_ARGS="
-    --tensor-model-parallel-size 1 \
-    --pipeline-model-parallel-size $NP \
-    --recompute-granularity full \
-    --recompute-method uniform \
-    --recompute-num-layers 1 \
-    --no-initialization \
-    --untie-embeddings-and-output-weights \
-    --distributed-backend nccl \
-    --sequence-parallel \
-    --num-layers 24 \
-    --hidden-size 1024 \
-    --num-attention-heads 16 \
-    --seq-length 1024 \
-    --max-position-embeddings 1024 \
-    --micro-batch-size 1 \
-    --global-batch-size 4 \
-    --lr 0.00015 \
-    --train-iters 3 \
-    --eval-iters 0 \
-    --lr-decay-iters 320000 \
-    --lr-decay-style cosine \
-    --min-lr 1.0e-5 \
-    --weight-decay 1e-2 \
-    --lr-warmup-fraction .01 \
-    --clip-grad 0.0 \
-    --attention-dropout 0.0 \
-    --hidden-dropout 0.0 \
-    --no-gradient-accumulation-fusion \
-    --use-distributed-optimizer
-"
+# Run script
+. $(dirname "${SCRIPT_PATH}")/run.sh
 
-DATA_ARGS="
-    --data-path $DATA_PATH \
-    --vocab-file $VOCAB_FILE \
-    --merge-file $MERGE_FILE \
-    --data-impl mmap \
-    --split 949,50,1
-"
-
-${MPIRUN} -np $NP -host $HOSTS $MPI_OPTIONS \
-    python $MEGATRON_PATH/pretrain_gpt.py $SPIRAL_ARGS $GPT_ARGS $DATA_ARGS --load $MODEL_PATH
+exit 0

--- a/examples/asplos25/mpirun_pretrain_gpt_spiral.sh
+++ b/examples/asplos25/mpirun_pretrain_gpt_spiral.sh
@@ -1,82 +1,39 @@
 #!/bin/bash
 
-MPIRUN=/usr/local/bin/mpirun
-MPI_OPTIONS="-mca btl ^openib -mca pml ucx"
-MEGATRON_PATH=$HOME/asplos2025/Megatron-LM-mcrl
+#SBATCH -J spiral
+#SBATCH --mincpus=4
+#SBATCH --mem=0
+#SBATCH --exclusive
 
-# Change for your system
+if [ -n "${SLURM_JOB_ID:-}" ] ; then
+    SCRIPT_PATH=$(scontrol show job "$SLURM_JOB_ID" | awk -F= '/Command=/{print $2}')
+else
+    SCRIPT_PATH=$(realpath "$0")
+fi
 
-## conda
-source ~/anaconda3/etc/profile.d/conda.sh
-conda activate Megatron-cuda11.7
+# Configuration for custom env
+. $(dirname "${SCRIPT_PATH}")/config.sh
 
-## mpi
-NP=4
-GPUS_PER_NODE=4
-HOSTS="b4:${GPUS_PER_NODE}" # b3:2,b4:2
-
-## torch dist.
-export MASTER_ADDR="b4"
-export MASTER_PORT=6003
-export CUDA_VISIBLE_DEVICES=0,1,2,3
-export CUDA_DEVICE_MAX_CONNECTIONS=1
-
-## Config file path
-MODEL_PATH=/home/n0/yujin/tmp/model/gpt-like-270m
-VOCAB_FILE=/home/n0/yujin/tmp/tokenizer/megatron/gpt2-vocab.json
-MERGE_FILE=/home/n0/yujin/tmp/tokenizer/megatron/gpt2-merges.txt
-
-DATASET_NAME=openwebtext
-DATASET_CONFIG=plan_text
-DATA_PATH=/data/z0/heehoon/openwebtext-mg/openwebtext_text_document
-
-# --spiral-stage-optimizer
-SPIRAL_ARGS="
+# Configuration for spiral training
+EXTRA_ARGS="
     --spiral \
     --spiral-remap \
-    --spiral-forward-virtual-size 2 \
-    --spiral-backward-virtual-size 3 \
+    --spiral-forward-virtual-size $SPIRAL_FWD \
+    --spiral-backward-virtual-size $SPIRAL_BWD \
     --spiral-recompute-activations \
-    --spiral-debug-backend \
+    --overlap-p2p-communication \
     --megatron-mpi
 "
 
-GPT_ARGS="
-    --tensor-model-parallel-size 1 \
-    --pipeline-model-parallel-size $NP \
-    --no-initialization \
-    --untie-embeddings-and-output-weights \
-    --distributed-backend nccl \
-    --overlap-p2p-communication \
-    --sequence-parallel \
-    --num-layers 24 \
-    --hidden-size 1024 \
-    --num-attention-heads 16 \
-    --seq-length 1024 \
-    --max-position-embeddings 1024 \
-    --micro-batch-size 1 \
-    --global-batch-size 4 \
-    --lr 0.00015 \
-    --train-iters 3 \
-    --eval-iters 0 \
-    --lr-decay-iters 320000 \
-    --lr-decay-style cosine \
-    --min-lr 1.0e-5 \
-    --weight-decay 1e-2 \
-    --lr-warmup-fraction .01 \
-    --clip-grad 0.0 \
-    --attention-dropout 0.0 \
-    --hidden-dropout 0.0 \
-    --no-gradient-accumulation-fusion
-"
+if [ ${SPIRAL_STAGED_OPTIMIZER} == "YES" ]; then
+    EXTRA_ARGS+=" --spiral-stage-optimizer"
+fi
 
-DATA_ARGS="
-    --data-path $DATA_PATH \
-    --vocab-file $VOCAB_FILE \
-    --merge-file $MERGE_FILE \
-    --data-impl mmap \
-    --split 949,50,1
-"
+if [ ${SPIRAL_DEBUG_BACKEND} == "YES" ]; then
+    EXTRA_ARGS+=" --spiral-debug-backend"
+fi
 
-${MPIRUN} -np $NP -host $HOSTS $MPI_OPTIONS \
-    python $MEGATRON_PATH/pretrain_gpt.py $SPIRAL_ARGS $GPT_ARGS $DATA_ARGS --load $MODEL_PATH
+# Run script
+. $(dirname "${SCRIPT_PATH}")/run.sh
+
+exit 0

--- a/examples/asplos25/run.sh
+++ b/examples/asplos25/run.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+
+ulimit -v unlimited
+
+## torch dist.
+export MASTER_ADDR=$(echo $UNWRAPPED_NODELIST | awk '{print $1}')
+export MASTER_PORT=6000
+export CUDA_VISIBLE_DEVICES=0,1,2,3
+export CUDA_DEVICE_MAX_CONNECTIONS=1
+
+
+DISTRIBUTED_ARGS="
+    --tensor-model-parallel-size 1 \
+    --pipeline-model-parallel-size $NP \
+    --distributed-backend nccl \
+    --overlap-p2p-communication \
+    --master-addr $MASTER_ADDR \
+    --master-port $MASTER_PORT
+"
+
+GPT_ARGS="
+    --no-initialization \
+    --untie-embeddings-and-output-weights \
+    --sequence-parallel \
+    --num-layers $LAYER \
+    --hidden-size $HIDDEN \
+    --num-attention-heads $HEAD \
+    --seq-length 1024 \
+    --max-position-embeddings 1024 \
+    --micro-batch-size $MBS \
+    --global-batch-size $(( $MBS * $NP )) \
+    --lr 0.00015 \
+    --train-iters $TRAIN_ITER \
+    --log-interval $LOG_ITER \
+    --eval-iters $EVAL_ITER \
+    --lr-decay-iters 320000 \
+    --lr-decay-style cosine \
+    --min-lr 1.0e-5 \
+    --weight-decay 1e-2 \
+    --lr-warmup-fraction .01 \
+    --clip-grad 0.0 \
+    --attention-dropout 0.0 \
+    --hidden-dropout 0.0 \
+    --no-gradient-accumulation-fusion
+"
+
+DATA_ARGS="
+    --data-path $DATA_PATH \
+    --vocab-file $VOCAB_FILE \
+    --merge-file $MERGE_FILE \
+    --data-impl mmap \
+    --split 949,50,1
+"
+
+EXEC_CMD="python ${MEGATRON_PATH}/pretrain_gpt.py ${EXTRA_ARGS} ${DISTRIBUTED_ARGS} ${GPT_ARGS} ${DATA_ARGS}"
+
+if [ ${NSYS_ENABLE} == "YES" ]; then
+    EXEC_CMD="${NSYS} profile -t cuda,nvtx -o ${NSYS_OUTPUT}_%q{OMPI_COMM_WORLD_RANK} --force-overwrite true ${EXEC_CMD}"
+fi
+
+${MPIRUN} -np $NP -host $HOSTS $MPI_OPTIONS ${EXEC_CMD}


### PR DESCRIPTION
I organized script files that work with slurm cluster.
To execute, only need to modify the environment variables in `config.sh`

- `run.sh`: script common to all scheduling
- `mpirun_pretrain_gpt_{schedule}.sh`: configurations that apply to each scheduling
- `config.sh`: configurations specific to your running environment