### PR TITLE
Correct SpiralStageOptimizer

### DIFF
--- a/csrc/common/thread_pool.hpp
+++ b/csrc/common/thread_pool.hpp
@@ -11,7 +11,7 @@
 #include <utility>
 #include <vector>
 
-#define _DEBUG_THREAD_POOL false
+#define _DEBUG_THREAD_POOL true
 
 using namespace std;
 
@@ -24,7 +24,7 @@ public:
   future<typename result_of<F(Args...)>::type> submit(F&& f, Args&&... args);
 
   void execute();
-  void flush();
+  void flush(size_t jcnt);
 
 private:
   const size_t _max_threads;
@@ -155,14 +155,19 @@ void ThreadPool::execute()
   }
 }
 
-void ThreadPool::flush()
+void ThreadPool::flush(size_t jcnt)
 {
-  unique_lock<mutex> lck_done(_jqdm);
-
-  if (_DEBUG_THREAD_POOL) {
-    printf("(pid:%ld) ThreadPool::flush (done:%ld)\n", (long)getpid(),
-           _jq_done_size.load());
+  while (true) {
+    unique_lock<mutex> lck_done(_jqdm);
+    if (_DEBUG_THREAD_POOL) {
+      printf("(pid:%ld) ThreadPool::flush (done:%ld)\n", (long)getpid(),
+            _jq_done_size.load());
+    }
+    assert(_jq_done_size.load() <= jcnt);
+    if (_jq_done_size.load() == jcnt) {
+      queue<function<void(void)>>().swap(_jq_done);
+      _jq_done_size = 0;
+      break;
+    }
   }
-  queue<function<void(void)>>().swap(_jq_done);
-  _jq_done_size = 0;
 }

--- a/csrc/common/thread_pool.hpp
+++ b/csrc/common/thread_pool.hpp
@@ -11,7 +11,7 @@
 #include <utility>
 #include <vector>
 
-#define _DEBUG_THREAD_POOL true
+#define _DEBUG_THREAD_POOL false
 
 using namespace std;
 
@@ -161,7 +161,7 @@ void ThreadPool::flush(size_t jcnt)
     unique_lock<mutex> lck_done(_jqdm);
     if (_DEBUG_THREAD_POOL) {
       printf("(pid:%ld) ThreadPool::flush (done:%ld)\n", (long)getpid(),
-            _jq_done_size.load());
+             _jq_done_size.load());
     }
     assert(_jq_done_size.load() <= jcnt);
     if (_jq_done_size.load() == jcnt) {

--- a/csrc/spiral_cpu_adam/cpu_adam.cpp
+++ b/csrc/spiral_cpu_adam/cpu_adam.cpp
@@ -1,4 +1,4 @@
-#include "cpu_adam.h"
+#include "cpu_adam.hpp"
 #include <cassert>
 #include <iostream>
 #include <memory>
@@ -25,7 +25,7 @@
 #include <unistd.h>
 
 struct ThreadSafeOptimizer {
-  Adam_Optimizer opt;
+  SpiralAdamOptimizer opt;
   ThreadPool pool;
   std::vector<std::future<int>>
       futures;           // Storage for futures returned by threads
@@ -34,7 +34,7 @@ struct ThreadSafeOptimizer {
   const bool should_log;
   std::mutex m;
 
-  ThreadSafeOptimizer(Adam_Optimizer&& opt, const int nparams, const int pool_size, const bool should_log)
+  ThreadSafeOptimizer(SpiralAdamOptimizer&& opt, const int nparams, const int pool_size, const bool should_log)
     : opt(opt), pool(pool_size), nparams(nparams), nparams_submitted(0),
       should_log(should_log)
   {}
@@ -54,7 +54,7 @@ int spiral_create_adam_optimizer(int optimizer_id,
                                  bool should_log)
 {
   auto opt =
-      Adam_Optimizer(alpha, betta1, betta2, eps, weight_decay, adamw_mode);
+      SpiralAdamOptimizer(alpha, betta1, betta2, eps, weight_decay, adamw_mode);
 
   if (pool_size == 0 || pool_size > nparams)
     pool_size = nparams;

--- a/csrc/spiral_cpu_adam/cpu_adam.cpp
+++ b/csrc/spiral_cpu_adam/cpu_adam.cpp
@@ -24,6 +24,8 @@
 #include <thread>
 #include <unistd.h>
 
+#define _DEBUG_OPTIMIZER false // for debugging Tensor values
+
 struct ThreadSafeOptimizer {
   SpiralAdamOptimizer opt;
   ThreadPool pool;
@@ -34,7 +36,10 @@ struct ThreadSafeOptimizer {
   const bool should_log;
   std::mutex m;
 
-  ThreadSafeOptimizer(SpiralAdamOptimizer&& opt, const int nparams, const int pool_size, const bool should_log)
+  ThreadSafeOptimizer(SpiralAdamOptimizer&& opt,
+                      const int nparams,
+                      const int pool_size,
+                      const bool should_log)
     : opt(opt), pool(pool_size), nparams(nparams), nparams_submitted(0),
       should_log(should_log)
   {}
@@ -65,7 +70,8 @@ int spiral_create_adam_optimizer(int optimizer_id,
       std::move(opt), nparams, pool_size, should_log);
 
   if (should_log) {
-    printf("[%ld] ThreadSafeOptimizer #%d is created with %d threads for %d params.\n",
+    printf("[%ld] ThreadSafeOptimizer #%d is created with %d threads for %d "
+           "params.\n",
            (long)getpid(), optimizer_id, pool_size, nparams);
   }
 
@@ -149,11 +155,31 @@ int _spiral_adam_step(int optimizer_id,
   float* exp_avg_ptr = (float*)exp_avg_c.data_ptr();
   float* exp_avg_sq_ptr = (float*)exp_avg_sq_c.data_ptr();
 
+  if (_DEBUG_OPTIMIZER) {
+    printf("Updating param=(%p,%f,%zu) with grad=(%p,%f,%zu), "
+           "momentum=(%p,%f,%zu), variance=(%p,%f,%zu)\n",
+           params_ptr, at::mean(params).item().toFloat(), params_c.numel(),
+           grads_ptr, at::mean(grads).item().toFloat(), grads_c.numel(),
+           exp_avg_ptr, at::mean(exp_avg).item().toFloat(), exp_avg_c.numel(),
+           exp_avg_sq_ptr, at::mean(exp_avg_sq).item().toFloat(),
+           exp_avg_sq_c.numel());
+  }
+
   ts_opt->opt.IncrementStep(step, beta1, beta2);
   ts_opt->opt.update_state(lr, epsilon, weight_decay, bias_correction);
   ts_opt->opt.Step_8(params_ptr, grads_ptr, exp_avg_ptr, exp_avg_sq_ptr,
                      params_c.numel(), nullptr,
                      (params.options().dtype() == at::kHalf));
+
+  if (_DEBUG_OPTIMIZER) {
+    printf("Updated param=(%p,%f,%zu) with grad=(%p,%f,%zu), "
+           "momentum=(%p,%f,%zu), variance=(%p,%f,%zu)\n",
+           params_ptr, at::mean(params).item().toFloat(), params_c.numel(),
+           grads_ptr, at::mean(grads).item().toFloat(), grads_c.numel(),
+           exp_avg_ptr, at::mean(exp_avg).item().toFloat(), exp_avg_c.numel(),
+           exp_avg_sq_ptr, at::mean(exp_avg_sq).item().toFloat(),
+           exp_avg_sq_c.numel());
+  }
 
 #if defined(__ENABLE_CUDA__) or defined(__ENABLE_CANN__)
   ts_opt->opt.SynchronizeStreams();
@@ -306,24 +332,27 @@ void spiral_adam_synchronize(int optimizer_id)
              ts_opt->nparams);
     }
     if (ts_opt->nparams_submitted == ts_opt->nparams) {
-      assert(ts_opt->futures.size() == ts_opt->nparams);
+      assert(ts_opt->futures.size() ==
+             ts_opt->nparams); // assert all params submitted
       break;
     }
   }
 
+  size_t fcnt = 0;
   for (auto& f : ts_opt->futures) {
     if (f.get() != 0) {
       // Non-zero future value indicates an error
       throw std::runtime_error("Error produced during Adam step is detected");
     }
+    fcnt++;
   }
-
-  ts_opt->pool.flush();
+  assert(fcnt == ts_opt->nparams); // assert all submitted finished
 
   {
     std::lock_guard<std::mutex> lck(ts_opt->m);
     ts_opt->futures.clear();
     ts_opt->nparams_submitted = 0;
+    ts_opt->pool.flush(ts_opt->nparams);
   }
 
   if (ts_opt->should_log) {

--- a/csrc/spiral_cpu_adam/cpu_adam.cpp
+++ b/csrc/spiral_cpu_adam/cpu_adam.cpp
@@ -27,7 +27,8 @@
 #define _DEBUG_OPTIMIZER false // for debugging Tensor values
 
 struct ThreadSafeOptimizer {
-  SpiralAdamOptimizer opt;
+  std::unordered_map<int, std::shared_ptr<void>>
+      group_s_opts; // Optimizer shared by a parameter group
   ThreadPool pool;
   std::vector<std::future<int>>
       futures;           // Storage for futures returned by threads
@@ -36,18 +37,20 @@ struct ThreadSafeOptimizer {
   const bool should_log;
   std::mutex m;
 
-  ThreadSafeOptimizer(SpiralAdamOptimizer&& opt,
-                      const int nparams,
-                      const int pool_size,
-                      const bool should_log)
-    : opt(opt), pool(pool_size), nparams(nparams), nparams_submitted(0),
-      should_log(should_log)
+  ThreadSafeOptimizer(
+      std::unordered_map<int, std::shared_ptr<void>> group_s_opts,
+      const int nparams,
+      const int pool_size,
+      const bool should_log)
+    : group_s_opts(group_s_opts), pool(pool_size), nparams(nparams),
+      nparams_submitted(0), should_log(should_log)
   {}
 };
 
 static std::unordered_map<int, std::shared_ptr<void>> s_optimizers;
 
 int spiral_create_adam_optimizer(int optimizer_id,
+                                 int ngroups,
                                  int nparams,
                                  int pool_size,
                                  float alpha,
@@ -58,8 +61,17 @@ int spiral_create_adam_optimizer(int optimizer_id,
                                  bool adamw_mode,
                                  bool should_log)
 {
-  auto opt =
-      SpiralAdamOptimizer(alpha, betta1, betta2, eps, weight_decay, adamw_mode);
+  /*
+   * Each backward stage has a ThreadSafeOptimizer and a ThreadPool.
+   * - ThreadSafeOptimizer has a SpiralCPUAdamOptimizer for each parameter group
+   * (mainly a weight group and a bias group).
+   * - ThreadPool is shared between all ThreadSafeOptimizers.
+   */
+  std::unordered_map<int, std::shared_ptr<void>> group_s_opts;
+  for (int i = 0; i < ngroups; i++) {
+    group_s_opts[i] = std::make_shared<SpiralAdamOptimizer>(
+        alpha, betta1, betta2, eps, weight_decay, adamw_mode);
+  }
 
   if (pool_size == 0 || pool_size > nparams)
     pool_size = nparams;
@@ -67,12 +79,13 @@ int spiral_create_adam_optimizer(int optimizer_id,
     throw std::runtime_error("Invalid thread pool size");
 
   s_optimizers[optimizer_id] = std::make_shared<ThreadSafeOptimizer>(
-      std::move(opt), nparams, pool_size, should_log);
+      group_s_opts, nparams, pool_size, should_log);
 
   if (should_log) {
     printf("[%ld] ThreadSafeOptimizer #%d is created with %d threads for %d "
+           "groups %d "
            "params.\n",
-           (long)getpid(), optimizer_id, pool_size, nparams);
+           (long)getpid(), optimizer_id, pool_size, ngroups, nparams);
   }
 
   if (should_log) {
@@ -112,6 +125,7 @@ int spiral_destroy_adam_optimizer(int optimizer_id)
 }
 
 int _spiral_adam_step(int optimizer_id,
+                      int group_id,
                       size_t step,
                       float lr,
                       float beta1,
@@ -165,11 +179,17 @@ int _spiral_adam_step(int optimizer_id,
            exp_avg_sq_c.numel());
   }
 
-  ts_opt->opt.IncrementStep(step, beta1, beta2);
-  ts_opt->opt.update_state(lr, epsilon, weight_decay, bias_correction);
-  ts_opt->opt.Step_8(params_ptr, grads_ptr, exp_avg_ptr, exp_avg_sq_ptr,
-                     params_c.numel(), nullptr,
-                     (params.options().dtype() == at::kHalf));
+  auto group_s_opt = std::static_pointer_cast<SpiralAdamOptimizer>(
+      ts_opt->group_s_opts[group_id]);
+
+  // Modifying the states of group_s_opt is safe, since param_group shares the
+  // same state value refer to megatron/spiral/cpu_adam.py step()
+  group_s_opt->IncrementStep(step, beta1, beta2);
+  group_s_opt->update_state(lr, epsilon, weight_decay, bias_correction);
+
+  group_s_opt->Step_8(params_ptr, grads_ptr, exp_avg_ptr, exp_avg_sq_ptr,
+                      params_c.numel(), nullptr,
+                      (params.options().dtype() == at::kHalf));
 
   if (_DEBUG_OPTIMIZER) {
     printf("Updated param=(%p,%f,%zu) with grad=(%p,%f,%zu), "
@@ -182,12 +202,13 @@ int _spiral_adam_step(int optimizer_id,
   }
 
 #if defined(__ENABLE_CUDA__) or defined(__ENABLE_CANN__)
-  ts_opt->opt.SynchronizeStreams();
+  group_s_opt->SynchronizeStreams();
 #endif
   return 0;
 }
 
 int _spiral_adam_step_plus_copy(int optimizer_id,
+                                int group_id,
                                 size_t step,
                                 float lr,
                                 float beta1,
@@ -234,13 +255,43 @@ int _spiral_adam_step_plus_copy(int optimizer_id,
   float* exp_avg_ptr = (float*)exp_avg_c.data_ptr();
   float* exp_avg_sq_ptr = (float*)exp_avg_sq_c.data_ptr();
 
-  ts_opt->opt.IncrementStep(step, beta1, beta2);
-  ts_opt->opt.update_state(lr, epsilon, weight_decay, bias_correction);
-  ts_opt->opt.Step_8(params_ptr, grads_ptr, exp_avg_ptr, exp_avg_sq_ptr,
-                     params_c.numel(), device_params_ptr,
-                     (params.options().dtype() == at::kHalf));
+  if (_DEBUG_OPTIMIZER) {
+    printf("Updating param=(%p,%f,%zu) device_parm=(%p,%f,%zu) with "
+           "grad=(%p,%f,%zu), "
+           "momentum=(%p,%f,%zu), variance=(%p,%f,%zu)\n",
+           params_ptr, at::mean(params).item().toFloat(), params_c.numel(),
+           device_params_ptr, at::mean(device_params).item().toFloat(),
+           device_params_c.numel(), grads_ptr, at::mean(grads).item().toFloat(),
+           grads_c.numel(), exp_avg_ptr, at::mean(exp_avg).item().toFloat(),
+           exp_avg_c.numel(), exp_avg_sq_ptr,
+           at::mean(exp_avg_sq).item().toFloat(), exp_avg_sq_c.numel());
+  }
 
-  ts_opt->opt.SynchronizeStreams();
+  auto group_s_opt = std::static_pointer_cast<SpiralAdamOptimizer>(
+      ts_opt->group_s_opts[group_id]);
+
+  // Modifying the states of group_s_opt is safe, since param_group shares the
+  // same state value refer to megatron/spiral/cpu_adam.py step()
+  group_s_opt->IncrementStep(step, beta1, beta2);
+  group_s_opt->update_state(lr, epsilon, weight_decay, bias_correction);
+
+  group_s_opt->Step_8(params_ptr, grads_ptr, exp_avg_ptr, exp_avg_sq_ptr,
+                      params_c.numel(), device_params_ptr,
+                      (params.options().dtype() == at::kHalf));
+
+  if (_DEBUG_OPTIMIZER) {
+    printf("Updated param=(%p,%f,%zu) device_parm=(%p,%f,%zu) with "
+           "grad=(%p,%f,%zu), "
+           "momentum=(%p,%f,%zu), variance=(%p,%f,%zu)\n",
+           params_ptr, at::mean(params).item().toFloat(), params_c.numel(),
+           device_params_ptr, at::mean(device_params).item().toFloat(),
+           device_params_c.numel(), grads_ptr, at::mean(grads).item().toFloat(),
+           grads_c.numel(), exp_avg_ptr, at::mean(exp_avg).item().toFloat(),
+           exp_avg_c.numel(), exp_avg_sq_ptr,
+           at::mean(exp_avg_sq).item().toFloat(), exp_avg_sq_c.numel());
+  }
+
+  group_s_opt->SynchronizeStreams();
 #else
   assert(false);
 #endif
@@ -248,6 +299,7 @@ int _spiral_adam_step_plus_copy(int optimizer_id,
 }
 
 int spiral_adam_step(int optimizer_id,
+                     int group_id,
                      size_t step,
                      float lr,
                      float beta1,
@@ -274,15 +326,16 @@ int spiral_adam_step(int optimizer_id,
   }
 
   ts_opt->futures.emplace_back(
-      ts_opt->pool.submit(_spiral_adam_step, optimizer_id, step, lr, beta1,
-                          beta2, epsilon, weight_decay, bias_correction, params,
-                          grads, exp_avg, exp_avg_sq, ev_long));
+      ts_opt->pool.submit(_spiral_adam_step, optimizer_id, group_id, step, lr,
+                          beta1, beta2, epsilon, weight_decay, bias_correction,
+                          params, grads, exp_avg, exp_avg_sq, ev_long));
   ts_opt->nparams_submitted++;
 
   return 0;
 }
 
 int spiral_adam_step_plus_copy(int optimizer_id,
+                               int group_id,
                                size_t step,
                                float lr,
                                float beta1,
@@ -310,8 +363,8 @@ int spiral_adam_step_plus_copy(int optimizer_id,
   }
 
   ts_opt->futures.emplace_back(ts_opt->pool.submit(
-      _spiral_adam_step_plus_copy, optimizer_id, step, lr, beta1, beta2,
-      epsilon, weight_decay, bias_correction, params, grads, exp_avg,
+      _spiral_adam_step_plus_copy, optimizer_id, group_id, step, lr, beta1,
+      beta2, epsilon, weight_decay, bias_correction, params, grads, exp_avg,
       exp_avg_sq, device_params, ev_long));
   ts_opt->nparams_submitted++;
 

--- a/csrc/spiral_cpu_adam/cpu_adam.hpp
+++ b/csrc/spiral_cpu_adam/cpu_adam.hpp
@@ -1,0 +1,426 @@
+// Copyright (c) Microsoft Corporation.
+// SPDX-License-Identifier: Apache-2.0
+
+// DeepSpeed Team
+
+#pragma once
+
+#define NOMINMAX // Windows idiosyncrasy
+                 // https://stackoverflow.com/questions/4913922/possible-problems-with-nominmax-on-visual-c
+
+#include "simd.h"
+#include <cassert>
+#include <stdio.h>
+#include <torch/extension.h>
+
+#if defined(__ENABLE_CUDA__)
+#include "cuda.h"
+#include "custom_cuda_layers.h"
+#include <cuda_fp16.h>
+#include <cuda_runtime_api.h>
+typedef __half ds_half_precision_t;
+#elif defined(__ENABLE_CANN__)
+#include "acl/acl.h"
+#include "torch_npu/csrc/core/npu/NPUStream.h"
+typedef c10::Half ds_half_precision_t;
+#else
+#include <cmath>
+typedef unsigned short ds_half_precision_t;
+#endif
+
+#define STEP(SPAN)                                                             \
+  void Step_##SPAN(float* _params, float* grads, float* _exp_avg,              \
+                   float* _exp_avg_sq, size_t _param_size,                     \
+                   ds_half_precision_t* dev_param = nullptr,                   \
+                   bool half_precision = false);
+
+class SpiralAdamOptimizer {
+public:
+  SpiralAdamOptimizer(float alpha = 1e-3,
+                        float betta1 = 0.9,
+                        float betta2 = 0.999,
+                        float eps = 1e-8,
+                        float weight_decay = 0,
+                        bool adamw_mode = true)
+    : _alpha(alpha), _betta1(betta1), _betta2(betta2), _eps(eps),
+      _weight_decay(weight_decay), _betta1_t(1.0), _betta2_t(1.0), _step(0),
+      _adamw_mode(adamw_mode)
+  {
+#if defined(__ENABLE_CUDA__)
+    cudaMallocHost((void**)_doubled_buffer, TILE * sizeof(float));
+    cudaMallocHost((void**)(_doubled_buffer + 1), TILE * sizeof(float));
+
+    _streams[0] = TrainingContext::Instance().GetCurrentStream();
+    _streams[1] = TrainingContext::Instance().GetNewStream();
+    _buf_index = false;
+#elif defined(__ENABLE_CANN__)
+    aclrtMallocHost((void**)_doubled_buffer, TILE * sizeof(float));
+    aclrtMallocHost((void**)(_doubled_buffer + 1), TILE * sizeof(float));
+
+    _buf_index = false;
+#endif
+  }
+  ~SpiralAdamOptimizer()
+  {
+#if defined(__ENABLE_CUDA__)
+    cudaFreeHost(_doubled_buffer[0]);
+    cudaFreeHost(_doubled_buffer[1]);
+#elif defined(__ENABLE_CANN__)
+    aclrtFreeHost(_doubled_buffer[0]);
+    aclrtFreeHost(_doubled_buffer[1]);
+#endif
+  }
+
+#if defined(__AVX512__) or defined(__AVX256__)
+  template <int span>
+  void Step_AVX(size_t* rounded_size,
+                float* _params,
+                float* grads,
+                float* _exp_avg,
+                float* _exp_avg_sq,
+                size_t param_size,
+                ds_half_precision_t* dev_param = nullptr,
+                bool half_precision = false);
+#endif
+  STEP(1)
+  STEP(4)
+  STEP(8)
+#if defined(__ENABLE_CUDA__)
+  inline void SynchronizeStreams()
+  {
+    for (int i = 0; i < 2; i++)
+      cudaStreamSynchronize(_streams[i]);
+  }
+#elif defined(__ENABLE_CANN__)
+  inline void SynchronizeStreams()
+  {
+    for (int i = 0; i < 2; i++)
+      aclrtSynchronizeStream(_streams[i].stream());
+  }
+#endif
+  inline void IncrementStep(size_t step, float beta1, float beta2)
+  {
+    if (beta1 != _betta1 || beta2 != _betta2) {
+      _step = step;
+      _betta1 = beta1;
+      _betta2 = beta2;
+      _betta1_t = std::pow(_betta1, step);
+      _betta2_t = std::pow(_betta2, step);
+    } else {
+      _step++;
+      if (_step != step) {
+        _betta1_t = std::pow(_betta1, step);
+        _betta2_t = std::pow(_betta2, step);
+        _step = step;
+      } else {
+        _betta1_t *= _betta1;
+        _betta2_t *= _betta2;
+      }
+    }
+  }
+  inline void update_state(float lr,
+                           float epsilon,
+                           float weight_decay,
+                           bool bias_correction)
+  {
+    _alpha = lr;
+    _eps = epsilon;
+    _weight_decay = weight_decay;
+
+    _bias_correction1 = 1.0f;
+    _bias_correction2 = 1.0f;
+    if (bias_correction == 1) {
+      _bias_correction1 = 1 - _betta1_t;
+      _bias_correction2 = 1 / sqrt(1 - _betta2_t);
+    }
+  }
+
+private:
+  float _alpha;
+  float _betta1;
+  float _betta2;
+  float _eps;
+  float _weight_decay;
+
+  float _betta1_t;
+  float _betta2_t;
+  size_t _step;
+
+  float _bias_correction1;
+  float _bias_correction2;
+
+  bool _adamw_mode;
+
+#if defined(__ENABLE_CUDA__)
+  float* _doubled_buffer[2];
+  cudaStream_t _streams[2];
+  bool _buf_index;
+#elif defined(__ENABLE_CANN__)
+  float* _doubled_buffer[2];
+  c10_npu::NPUStream _streams[2] = { c10_npu::getCurrentNPUStream(),
+                                     c10_npu::getNPUStreamFromPool() };
+  bool _buf_index;
+#endif
+};
+
+#if defined(__AVX512__) or defined(__AVX256__)
+template <int span>
+void SpiralAdamOptimizer::Step_AVX(size_t* rounded_size,
+                                     float* _params,
+                                     float* grads,
+                                     float* _exp_avg,
+                                     float* _exp_avg_sq,
+                                     size_t _param_size,
+                                     ds_half_precision_t* dev_params,
+                                     bool half_precision)
+{
+  size_t new_rounded_size = 0;
+  int rshft = half_precision ? 1 : 0;
+
+  AVX_Data betta1_4;
+  betta1_4.data = SIMD_SET(_betta1);
+  AVX_Data betta2_4;
+  betta2_4.data = SIMD_SET(_betta2);
+
+  float betta1_minus1 = 1 - _betta1;
+  float betta2_minus1 = 1 - _betta2;
+  AVX_Data betta1_minus1_4;
+  betta1_minus1_4.data = SIMD_SET(betta1_minus1);
+  AVX_Data betta2_minus1_4;
+  betta2_minus1_4.data = SIMD_SET(betta2_minus1);
+
+  AVX_Data bias2_sqrt;
+  bias2_sqrt.data = SIMD_SET(_bias_correction2);
+
+  AVX_Data eps_4;
+  eps_4.data = SIMD_SET(_eps);
+
+  float step_size = -1 * _alpha / _bias_correction1;
+  AVX_Data step_size_4;
+  step_size_4.data = SIMD_SET(step_size);
+
+  float w_decay = -1 * _alpha * _weight_decay;
+  AVX_Data weight_decay4;
+  if (_weight_decay > 0)
+    weight_decay4.data =
+        (_adamw_mode ? SIMD_SET(w_decay) : SIMD_SET(_weight_decay));
+  new_rounded_size = ROUND_DOWN(_param_size, SIMD_WIDTH * span);
+  for (size_t t = 0; t < new_rounded_size; t += TILE) {
+    size_t copy_size = TILE;
+    if ((t + TILE) > new_rounded_size)
+      copy_size = new_rounded_size - t;
+    size_t offset = copy_size + t;
+#if defined(__ENABLE_CUDA__)
+    if ((t / TILE) >= 2) {
+      cudaStreamSynchronize(_streams[_buf_index]);
+    }
+#elif defined(__ENABLE_CANN__)
+    if ((t / TILE) >= 2) {
+      aclrtSynchronizeStream(_streams[_buf_index].stream());
+    }
+#endif
+#pragma omp parallel for
+    for (size_t i = t; i < offset; i += SIMD_WIDTH * span) {
+      AVX_Data grad_4[span];
+      simd_load<span>(grad_4, grads + (i >> rshft), half_precision);
+
+      AVX_Data momentum_4[span];
+      simd_load<span>(momentum_4, _exp_avg + i, false);
+
+      AVX_Data variance_4[span];
+      simd_load<span>(variance_4, _exp_avg_sq + i, false);
+
+      AVX_Data param_4[span];
+      simd_load<span>(param_4, _params + (i >> rshft), half_precision);
+
+      if (_weight_decay > 0 && !_adamw_mode) {
+        simd_fma<span>(grad_4, param_4, weight_decay4, grad_4);
+      }
+
+      simd_mul<span>(momentum_4, momentum_4, betta1_4);
+      simd_fma<span>(momentum_4, grad_4, betta1_minus1_4, momentum_4);
+      simd_mul<span>(variance_4, variance_4, betta2_4);
+      simd_mul<span>(grad_4, grad_4, grad_4);
+      simd_fma<span>(variance_4, grad_4, betta2_minus1_4, variance_4);
+      simd_sqrt<span>(grad_4, variance_4);
+      simd_fma<span>(grad_4, grad_4, bias2_sqrt, eps_4);
+      simd_div<span>(grad_4, momentum_4, grad_4);
+
+      if (_weight_decay > 0 && _adamw_mode) {
+        simd_fma<span>(param_4, param_4, weight_decay4, param_4);
+      }
+
+      simd_fma<span>(param_4, grad_4, step_size_4, param_4);
+
+      simd_store<span>(_params + (i >> rshft), param_4, half_precision);
+#if defined(__ENABLE_CUDA__) or defined(__ENABLE_CANN__)
+      if (dev_params) {
+        simd_store<span>(_doubled_buffer[_buf_index] + (i - t), param_4,
+                         half_precision);
+      }
+#endif
+      simd_store<span>(_exp_avg + i, momentum_4, false);
+      simd_store<span>(_exp_avg_sq + i, variance_4, false);
+    }
+#if defined(__ENABLE_CUDA__)
+    if (dev_params) {
+      if (half_precision)
+        launch_param_update_half(_doubled_buffer[_buf_index], dev_params + t,
+                                 copy_size, _streams[_buf_index]);
+      else
+        launch_param_update(_doubled_buffer[_buf_index], dev_params + t,
+                            copy_size, _streams[_buf_index]);
+
+      _buf_index = !_buf_index;
+    }
+#elif defined(__ENABLE_CANN__)
+    if (dev_params) {
+      size_t memcpy_size = copy_size * sizeof(_doubled_buffer[_buf_index][0]);
+      if (half_precision)
+        memcpy_size /= 2;
+      aclrtMemcpy(dev_params + t, memcpy_size, _doubled_buffer[_buf_index],
+                  memcpy_size, aclrtMemcpyKind::ACL_MEMCPY_HOST_TO_DEVICE);
+
+      _buf_index = !_buf_index;
+    }
+#endif
+  }
+  *rounded_size = new_rounded_size;
+}
+#endif
+
+void SpiralAdamOptimizer::Step_1(float* _params,
+                                   float* grads,
+                                   float* _exp_avg,
+                                   float* _exp_avg_sq,
+                                   size_t _param_size,
+                                   ds_half_precision_t* dev_params,
+                                   bool half_precision)
+{
+  size_t rounded_size = 0;
+#if defined(__AVX512__) or defined(__AVX256__)
+  Step_AVX<1>(&rounded_size, _params, grads, _exp_avg, _exp_avg_sq, _param_size,
+              dev_params, half_precision);
+#endif
+  if (_param_size > rounded_size) {
+    float betta1_minus1 = 1 - _betta1;
+    float betta2_minus1 = 1 - _betta2;
+
+    float step_size = -1 * _alpha / _bias_correction1;
+    float w_decay = -1 * _alpha * _weight_decay;
+    ds_half_precision_t* grads_cast_h;
+    ds_half_precision_t* params_cast_h;
+    if (half_precision) {
+      grads_cast_h = reinterpret_cast<ds_half_precision_t*>(grads);
+      params_cast_h = reinterpret_cast<ds_half_precision_t*>(_params);
+    }
+
+    for (size_t t = rounded_size; t < _param_size; t += TILE) {
+      size_t copy_size = TILE;
+      if ((t + TILE) > _param_size)
+        copy_size = _param_size - t;
+      size_t offset = copy_size + t;
+#if defined(__ENABLE_CUDA__)
+      if ((t / TILE) >= 2) {
+        cudaStreamSynchronize(_streams[_buf_index]);
+      }
+#elif defined(__ENABLE_CANN__)
+      if ((t / TILE) >= 2) {
+        aclrtSynchronizeStream(_streams[_buf_index].stream());
+      }
+#endif
+#pragma omp parallel for
+      for (size_t k = t; k < offset; k++) {
+        float grad = half_precision ? (float)grads_cast_h[k] : grads[k];
+        float param = half_precision ? (float)params_cast_h[k] : _params[k];
+        float momentum = _exp_avg[k];
+        float variance = _exp_avg_sq[k];
+        if (_weight_decay > 0 && !_adamw_mode) {
+          grad = param * _weight_decay + grad;
+        }
+        momentum = momentum * _betta1;
+        momentum = grad * betta1_minus1 + momentum;
+
+        variance = variance * _betta2;
+        grad = grad * grad;
+        variance = grad * betta2_minus1 + variance;
+
+        grad = sqrt(variance);
+        grad = grad * _bias_correction2 + _eps;
+        grad = momentum / grad;
+        if (_weight_decay > 0 && _adamw_mode) {
+          param += w_decay * param;
+        }
+        param = grad * step_size + param;
+#if defined(__ENABLE_CUDA__) or defined(__ENABLE_CANN__)
+        if (dev_params)
+          _doubled_buffer[_buf_index][k - t] = param;
+#endif
+        if (half_precision)
+          params_cast_h[k] = (ds_half_precision_t)param;
+        else
+          _params[k] = param;
+        _exp_avg[k] = momentum;
+        _exp_avg_sq[k] = variance;
+      }
+#if defined(__ENABLE_CUDA__)
+      if (dev_params) {
+        launch_param_update(_doubled_buffer[_buf_index], dev_params + t,
+                            (copy_size), _streams[_buf_index]);
+
+        _buf_index = !_buf_index;
+      }
+#elif defined(__ENABLE_CANN__)
+      if (dev_params) {
+        size_t memcpy_size = copy_size * sizeof(_doubled_buffer[_buf_index][0]);
+        aclrtMemcpy(dev_params + t, memcpy_size, _doubled_buffer[_buf_index],
+                    memcpy_size, aclrtMemcpyKind::ACL_MEMCPY_HOST_TO_DEVICE);
+
+        _buf_index = !_buf_index;
+      }
+#endif
+    }
+  }
+}
+
+void SpiralAdamOptimizer::Step_4(float* _params,
+                                   float* grads,
+                                   float* _exp_avg,
+                                   float* _exp_avg_sq,
+                                   size_t _param_size,
+                                   ds_half_precision_t* dev_params,
+                                   bool half_precision)
+{
+  size_t rounded_size = 0;
+#if defined(__AVX512__) or defined(__AVX256__)
+  Step_AVX<4>(&rounded_size, _params, grads, _exp_avg, _exp_avg_sq, _param_size,
+              dev_params, half_precision);
+#endif
+  if (_param_size > rounded_size)
+    Step_1((_params + rounded_size), (grads + rounded_size),
+           (_exp_avg + rounded_size), (_exp_avg_sq + rounded_size),
+           (_param_size - rounded_size),
+           (dev_params != nullptr ? (dev_params + rounded_size) : dev_params),
+           half_precision);
+}
+
+void SpiralAdamOptimizer::Step_8(float* _params,
+                                   float* grads,
+                                   float* _exp_avg,
+                                   float* _exp_avg_sq,
+                                   size_t _param_size,
+                                   ds_half_precision_t* dev_params,
+                                   bool half_precision)
+{
+  size_t rounded_size = 0;
+#if defined(__AVX512__) or defined(__AVX256__)
+  Step_AVX<8>(&rounded_size, _params, grads, _exp_avg, _exp_avg_sq, _param_size,
+              dev_params, half_precision);
+#endif
+  if (_param_size > rounded_size)
+    Step_4((_params + rounded_size), (grads + rounded_size),
+           (_exp_avg + rounded_size), (_exp_avg_sq + rounded_size),
+           (_param_size - rounded_size),
+           (dev_params != nullptr ? (dev_params + rounded_size) : dev_params),
+           half_precision);
+}

--- a/megatron/core/parallel_state.py
+++ b/megatron/core/parallel_state.py
@@ -295,6 +295,10 @@ def initialize_model_parallel(
             embedding_ranks = ranks
             position_embedding_ranks = ranks
 
+            if _SPIRAL and _SPIRAL_REMAP:
+                spiral_embedding_ranks = ranks
+                spiral_position_embedding_ranks = ranks
+
         group = torch.distributed.new_group(embedding_ranks)
         if rank in embedding_ranks:
             _EMBEDDING_GROUP = group

--- a/megatron/core/pipeline_parallel/schedules.py
+++ b/megatron/core/pipeline_parallel/schedules.py
@@ -127,12 +127,12 @@ def get_forward_backward_func():
 
     """
     pipeline_model_parallel_size = parallel_state.get_pipeline_model_parallel_world_size()
-    if pipeline_model_parallel_size > 1:
-        if parallel_state.is_spiral_remap():
-            forward_backward_func = megatron.spiral.schedules.forward_backward_pipelining_with_spiral_remap
-        elif parallel_state.is_spiral():
-            forward_backward_func = megatron.spiral.schedules.forward_backward_pipelining_with_spiral
-        elif parallel_state.get_virtual_pipeline_model_parallel_world_size() is not None:
+    if parallel_state.is_spiral_remap():
+        forward_backward_func = megatron.spiral.schedules.forward_backward_pipelining_with_spiral_remap
+    elif parallel_state.is_spiral():
+        forward_backward_func = megatron.spiral.schedules.forward_backward_pipelining_with_spiral
+    elif pipeline_model_parallel_size > 1:
+        if parallel_state.get_virtual_pipeline_model_parallel_world_size() is not None:
             forward_backward_func = forward_backward_pipelining_with_interleaving
         else:
             forward_backward_func = forward_backward_pipelining_without_interleaving

--- a/megatron/optimizer/__init__.py
+++ b/megatron/optimizer/__init__.py
@@ -104,7 +104,6 @@ def get_megatron_optimizer(model,
     if (
         args.spiral
         and args.spiral_stage_optimizer
-        and args.spiral_backward_virtual_size > 1
     ):
         if not hasattr(model, "_spiral_optimizer_entered"):
             # NOTE (SpiralPipe) top level model[], recursively collect optimizer for each **BWD** stage. FWD stages are skipped, even though they will naturally be skipped due to logic in get_param_groups, in order to prevent optimizer with empty param group.

--- a/megatron/spiral/cpu_adam.py
+++ b/megatron/spiral/cpu_adam.py
@@ -103,6 +103,7 @@ class SpiralCPUAdam(torch.optim.Optimizer):
         self.ds_opt_adam = SpiralCPUAdamBuilder().load()
         self.ds_opt_adam.create_adam(
             self.opt_id,
+            len(self.param_groups),
             self.nparams,
             self.pool_size,
             lr,
@@ -201,6 +202,7 @@ class SpiralCPUAdam(torch.optim.Optimizer):
                 if fp16_param_groups is not None:
                     self.ds_opt_adam.adam_update_copy(
                         self.opt_id,
+                        group_id,
                         state["step"],
                         group["lr"],
                         beta1,
@@ -218,6 +220,7 @@ class SpiralCPUAdam(torch.optim.Optimizer):
                 else:
                     self.ds_opt_adam.adam_update(
                         self.opt_id,
+                        group_id,
                         state["step"],
                         group["lr"],
                         beta1,

--- a/megatron/spiral/init_context.py
+++ b/megatron/spiral/init_context.py
@@ -406,8 +406,7 @@ class SpiralInitContext(InsertPostInitMethodToModuleSubClasses):
             0,
             dtype=param.dtype,
             device=self.remote_device,
-            pin_memory=True,
-            # NOTE (SpiralPipe) In sprial_remap, SpiralCPUAllocator allocates to pin_memory automatically
+            # NOTE (SpiralPipe) pin_memory arg should not be passed
         )
 
         def _free_data(param: Parameter) -> None:
@@ -427,12 +426,14 @@ class SpiralInitContext(InsertPostInitMethodToModuleSubClasses):
                 if get_args().spiral_remap:
                     assert sbs.get_spiral_backward_stage_build_phase() is not None, \
                         "Offloading to empty spiral tensor should be executed only once during SpiralPipe with remapping backward stage build phase"
+                    # NOTE (SpiralPipe) pin_memory arg should not be passed when offloading to shared memory, since it transfers the data to pinned memory region
+                    param.spiral_tensor = torch.empty(param.spiral_shape, device=self.remote_device, dtype=param.dtype)
                 else:
                     assert sbs.get_spiral_forward_stage_build_phase() is not None, \
                         "Offloading to empty spiral tensor should be executed only once during SpiralPipe w/o remapping forward stage build phase"
-                param.spiral_tensor = param.data.to(
-                    device=self.remote_device, non_blocking=non_blocking,
-                ).pin_memory() # NOTE (SpiralPipe) In sprial_remap, SpiralCPUAllocator allocates to pin_memory automatically
+                    # NOTE (SpiralPipe) pin_memory arg can be passed, since it is not offloading to shared memory
+                    param.spiral_tensor = torch.empty(param.spiral_shape, device=self.remote_device, dtype=param.dtype, pin_memory=True)
+                param.spiral_tensor.copy_(param.data, non_blocking=non_blocking)
             else:
                 assert (
                     param.spiral_tensor.shape == param.data.shape

--- a/megatron/spiral/op_builder/cpu_adam.py
+++ b/megatron/spiral/op_builder/cpu_adam.py
@@ -18,14 +18,10 @@ class SpiralCPUAdamBuilder(CPUAdamBuilder):
         if self.build_for_cpu:
             return [
                 os.path.join(self.csrc, "spiral_cpu_adam/cpu_adam.cpp"),
-                os.path.join(
-                    self.csrc, "external/DeepSpeed/csrc/adam/cpu_adam_impl.cpp"
-                ),
             ]
 
         return [
             os.path.join(self.csrc, "spiral_cpu_adam/cpu_adam.cpp"),
-            os.path.join(self.csrc, "external/DeepSpeed/csrc/adam/cpu_adam_impl.cpp"),
             os.path.join(
                 self.csrc, "external/DeepSpeed/csrc/common/custom_cuda_kernel.cu"
             ),
@@ -46,8 +42,9 @@ class SpiralCPUAdamBuilder(CPUAdamBuilder):
 
         include_dirs=[
             os.path.join(self.csrc, 'external/spdlog/include'),
-            os.path.join(self.csrc, 'external/DeepSpeed/csrc/includes'),
+            os.path.join(self.csrc, "spiral_cpu_adam"),
             os.path.join(self.csrc, 'common'),
+            os.path.join(self.csrc, 'external/DeepSpeed/csrc/includes'),
         ]
 
         if self.build_for_cpu:

--- a/megatron/spiral/optimizer.py
+++ b/megatron/spiral/optimizer.py
@@ -50,7 +50,7 @@ class SpiralStageOptimizer:
 
         # Calculate r_grad_norm
         # TODO (SpiralPipe) This is a temporary solution by simply averaging the grad_norms
-        valid_grad_norm_values = filter(lambda x: x is not None, grad_norm_values)
+        valid_grad_norm_values = list(filter(lambda x: x is not None, grad_norm_values))
         r_grad_norm = (
             sum(valid_grad_norm_values) / len(grad_norm_values)
             if valid_grad_norm_values
@@ -58,10 +58,14 @@ class SpiralStageOptimizer:
         )
 
         # Calculate r_num_zeros_in_grad
-        valid_num_zeros_in_grad_values = filter(
-            lambda x: x is not None, num_zeros_in_grad_values
+        valid_num_zeros_in_grad_values = list(
+            filter(lambda x: x is not None, num_zeros_in_grad_values)
         )
-        r_num_zeros_in_grad = sum(valid_num_zeros_in_grad_values)
+        r_num_zeros_in_grad = (
+            sum(valid_num_zeros_in_grad_values)
+            if valid_num_zeros_in_grad_values
+            else None
+        )
 
         return r_update_successful, r_grad_norm, r_num_zeros_in_grad
 

--- a/megatron/spiral/p2p_communication.py
+++ b/megatron/spiral/p2p_communication.py
@@ -1,4 +1,5 @@
 from typing import Optional, List, Union, Callable, Tuple
+from collections import deque
 
 import nvtx
 import torch
@@ -9,7 +10,19 @@ from megatron.core import mpu
 # Types
 Shape = Union[List[int], torch.Size]
 
+# Constants
 MINIMIZE_INTERNODE_COMM = False # TODO (SpiralPipe) further optimizer internode comm.
+
+# Tensor stores to use for self send-recv
+# Only used when pipeline world size is 1
+# TODO (SpiralPipe) This is temporary solution to avoid breaking the code
+class NOP_Wait:
+    @staticmethod
+    def wait():
+        pass
+
+_self_send_recv_input_tensor_store = deque()
+_self_send_recv_output_tensor_grad_store = deque()
 
 def _batched_p2p_ops(
     *,
@@ -188,16 +201,22 @@ def recv_input_tensor(
     else:
         recv_rank = mpu.get_pipeline_model_parallel_prev_rank()
 
-    [input_tensor], reqs = _communicate(
-        tensor_sends=None,
-        send_ranks=None,
-        recv_ranks=[recv_rank],
-        tensor_shape=tensor_shape,
-        group=mpu.get_pipeline_model_parallel_group(),
-        batch_p2p_comm=batch_p2p_comm,
-        wait_on_reqs=not overlap_p2p_comm,
-        dtype=dtype,
-    )
+    if recv_rank != mpu.get_pipeline_model_parallel_rank():
+        [input_tensor], reqs = _communicate(
+            tensor_sends=None,
+            send_ranks=None,
+            recv_ranks=[recv_rank],
+            tensor_shape=tensor_shape,
+            group=mpu.get_pipeline_model_parallel_group(),
+            batch_p2p_comm=batch_p2p_comm,
+            wait_on_reqs=not overlap_p2p_comm,
+            dtype=dtype,
+        )
+    else:
+        # If we are receiving from ourselves, just pop the tensor from the store
+        input_tensor = _self_send_recv_input_tensor_store.popleft()
+        reqs = [NOP_Wait]
+
     if timers is not None:
         timers("recv_input_tensor").stop()
 
@@ -234,16 +253,22 @@ def send_output_tensor(
     else:
         send_rank = mpu.get_pipeline_model_parallel_next_rank()
 
-    _, reqs = _communicate(
-        tensor_sends=[output_tensor],
-        send_ranks=[send_rank],
-        recv_ranks=None,
-        tensor_shape=None,
-        group=mpu.get_pipeline_model_parallel_group(),
-        wait_on_reqs=not overlap_p2p_comm,
-        batch_p2p_comm=batch_p2p_comm,
-        dtype=None,
-    )
+    if send_rank != mpu.get_pipeline_model_parallel_rank():
+        _, reqs = _communicate(
+            tensor_sends=[output_tensor],
+            send_ranks=[send_rank],
+            recv_ranks=None,
+            tensor_shape=None,
+            group=mpu.get_pipeline_model_parallel_group(),
+            wait_on_reqs=not overlap_p2p_comm,
+            batch_p2p_comm=batch_p2p_comm,
+            dtype=None,
+        )
+    else:
+        # If we are sending to ourselves, just store the tensor for later
+        _self_send_recv_input_tensor_store.append(output_tensor.detach())
+        reqs = [NOP_Wait]
+
     if timers is not None:
         timers("send_output_tensor").stop()
 
@@ -301,16 +326,22 @@ def recv_output_tensor_grad(
         else:
             raise ValueError("Unknown pipeline parallelism type for spiral_p2p")
 
-    [output_tensor_grad], reqs = _communicate(
-        tensor_sends=None,
-        send_ranks=None,
-        recv_ranks=[recv_rank],
-        tensor_shape=tensor_shape,
-        group=mpu.get_pipeline_model_parallel_group(),
-        batch_p2p_comm=batch_p2p_comm,
-        wait_on_reqs=not overlap_p2p_comm,
-        dtype=dtype,
-    )
+    if recv_rank != mpu.get_pipeline_model_parallel_rank():
+        [output_tensor_grad], reqs = _communicate(
+            tensor_sends=None,
+            send_ranks=None,
+            recv_ranks=[recv_rank],
+            tensor_shape=tensor_shape,
+            group=mpu.get_pipeline_model_parallel_group(),
+            batch_p2p_comm=batch_p2p_comm,
+            wait_on_reqs=not overlap_p2p_comm,
+            dtype=dtype,
+        )
+    else:
+        # If we are receiving from ourselves, just pop the tensor from the store
+        output_tensor_grad = _self_send_recv_output_tensor_grad_store.popleft()
+        reqs = [NOP_Wait]
+
     if timers is not None:
         timers("output_tensor_grad").stop()
 
@@ -364,16 +395,22 @@ def send_input_tensor_grad(
         else:
             raise ValueError("Unknown pipeline parallelism type for spiral_p2p")
 
-    _, reqs = _communicate(
-        tensor_sends=[input_tensor_grad],
-        send_ranks=[send_rank],
-        recv_ranks=None,
-        tensor_shape=None,
-        group=mpu.get_pipeline_model_parallel_group(),
-        wait_on_reqs=not overlap_p2p_comm,
-        batch_p2p_comm=batch_p2p_comm,
-        dtype=None,
-    )
+    if send_rank != mpu.get_pipeline_model_parallel_rank():
+        _, reqs = _communicate(
+            tensor_sends=[input_tensor_grad],
+            send_ranks=[send_rank],
+            recv_ranks=None,
+            tensor_shape=None,
+            group=mpu.get_pipeline_model_parallel_group(),
+            wait_on_reqs=not overlap_p2p_comm,
+            batch_p2p_comm=batch_p2p_comm,
+            dtype=None,
+        )
+    else:
+        # If we are sending to ourselves, just store the tensor for later
+        _self_send_recv_output_tensor_grad_store.append(input_tensor_grad.detach())
+        reqs = [NOP_Wait]
+
     if timers is not None:
         timers("send_input_tensor_grad").stop()
 

--- a/megatron/spiral/schedules.py
+++ b/megatron/spiral/schedules.py
@@ -719,7 +719,7 @@ def forward_backward_pipelining_with_spiral_remap(
                 if i == num_microbatches - 1:
                     # notify free stream to act
                     compute_microbatches_end = get_thunder_cuda_manager().Event(
-                        "compute", "free", tag=f"compute:b{bwd_stage_id}end"
+                        "compute", None, tag=f"compute:b{bwd_stage_id}end"
                     )
                     if get_thunder_cuda_manager().record_event(compute_microbatches_end) == -1:
                         raise RuntimeError("record_event failed")
@@ -744,7 +744,7 @@ def forward_backward_pipelining_with_spiral_remap(
 
         with torch.cuda.stream(get_thunder_cuda_manager().Stream("free")):
             if (
-                get_thunder_cuda_manager().wait_event(compute_event_queries.pop(f"compute:b{bwd_stage_id}end"))
+                get_thunder_cuda_manager().wait_event(compute_event_queries.get(f"compute:b{bwd_stage_id}end"))
                 == -1
             ):
                 raise RuntimeError("wait_event failed")
@@ -766,6 +766,11 @@ def forward_backward_pipelining_with_spiral_remap(
         # if not spiral stage optimizer, then gradient should be manually reduced and offloaded after `forward_backward_func` at train_step()
         if optimize_after_bwd_stage:
             with torch.cuda.stream(get_thunder_cuda_manager().Stream("offload")):
+                if (
+                    get_thunder_cuda_manager().wait_event(compute_event_queries.pop(f"compute:b{bwd_stage_id}end"))
+                    == -1
+                ):
+                    raise RuntimeError("wait_event failed")
                 # reduce grads
                 optimizer[bwd_stage_id].reduce_model_grads(get_args(), get_timers())
                 # offload grads
@@ -1302,7 +1307,7 @@ def forward_backward_pipelining_with_spiral(
                 if i == num_microbatches - 1:
                     # notify free stream to act
                     compute_microbatches_end = get_thunder_cuda_manager().Event(
-                        "compute", "free", tag=f"compute:b{bwd_stage_id}end"
+                        "compute", None, tag=f"compute:b{bwd_stage_id}end"
                     )
                     if get_thunder_cuda_manager().record_event(compute_microbatches_end) == -1:
                         raise RuntimeError("record_event failed")
@@ -1327,7 +1332,7 @@ def forward_backward_pipelining_with_spiral(
 
         with torch.cuda.stream(get_thunder_cuda_manager().Stream("free")):
             if (
-                get_thunder_cuda_manager().wait_event(compute_event_queries.pop(f"compute:b{bwd_stage_id}end"))
+                get_thunder_cuda_manager().wait_event(compute_event_queries.get(f"compute:b{bwd_stage_id}end"))
                 == -1
             ):
                 raise RuntimeError("wait_event failed")
@@ -1349,6 +1354,11 @@ def forward_backward_pipelining_with_spiral(
         # if not spiral stage optimizer, then gradient should be manually reduced and offloaded after `forward_backward_func` at train_step()
         if optimize_after_bwd_stage:
             with torch.cuda.stream(get_thunder_cuda_manager().Stream("offload")):
+                if (
+                    get_thunder_cuda_manager().wait_event(compute_event_queries.pop(f"compute:b{bwd_stage_id}end"))
+                    == -1
+                ):
+                    raise RuntimeError("wait_event failed")
                 # reduce grads
                 optimizer[bwd_stage_id].reduce_model_grads(get_args(), get_timers())
                 # offload grads

--- a/megatron/spiral/schedules.py
+++ b/megatron/spiral/schedules.py
@@ -308,10 +308,12 @@ def forward_backward_pipelining_with_spiral_remap(
                         model[local_stage_id]
                         .module[local_phase_id]
                         .spiral_input_tensors.popleft()
+                        .detach()
+                        .requires_grad_()
                     )
-                    # Input ckpt must require grad before feeding to BWD
-                    if not input_ckpt_.requires_grad:
-                        input_ckpt_.requires_grad_()
+                    assert (
+                        input_ckpt_.requires_grad
+                    ), "Input ckpt must require grad before feeding to BWD"
                     insert_value_to_recvs.append(input_ckpt_)
                 else:
                     if _DEBUG_SCHEDULE:

--- a/megatron/spiral/schedules.py
+++ b/megatron/spiral/schedules.py
@@ -309,9 +309,9 @@ def forward_backward_pipelining_with_spiral_remap(
                         .module[local_phase_id]
                         .spiral_input_tensors.popleft()
                     )
-                    assert (
-                        input_ckpt_.requires_grad
-                    ), "Input ckpt must require grad before feeding to BWD"
+                    # Input ckpt must require grad before feeding to BWD
+                    if not input_ckpt_.requires_grad:
+                        input_ckpt_.requires_grad_()
                     insert_value_to_recvs.append(input_ckpt_)
                 else:
                     if _DEBUG_SCHEDULE:

--- a/megatron/training.py
+++ b/megatron/training.py
@@ -284,7 +284,7 @@ def get_model(model_provider_func, model_type=ModelType.encoder_or_decoder, wrap
             )
             this_model.model_type = model_type
             model.append(this_model)
-    elif mpu.get_pipeline_model_parallel_world_size() > 1 and mpu.is_spiral():
+    elif mpu.is_spiral():
         assert (
             model_type != ModelType.encoder_and_decoder
         ), "SpiralPipe not supported for model with both encoder and decoder"
@@ -670,7 +670,6 @@ def get_optimizer_param_scheduler(optimizer):
     if (
         args.spiral
         and args.spiral_stage_optimizer
-        and args.spiral_backward_virtual_size > 1
     ):
         if not hasattr(optimizer, "_spiral_optimizer_param_scheduler_entered"):
             assert isinstance(optimizer, SpiralStageOptimizer), "top level spiral stage optimizer should be SpiralStageOptimizer"


### PR DESCRIPTION
## Description
SpiralStageOptimizer is fixed! The root cause of the bug was data race between parameter groups (mainly, weight group and bias group of the parameters that are in the same backward stage). In cpu_adam.py, `state` values (such as weight_decay, epsilon, etc., that are passed to `step()`. Listed in below code.) differ between param_groups. Inside `_spiral_adam_step()`, `opt->IncrementStep()` and `opt->update_state()` is called with those state values. On param_group transition, the shared optimizer's state values are overriden, leading to overflow like the below pic. So, I created parameter group-wise shared optimizer. 

## Test
I have tested the lm loss with 1000 iterations.

```
// The `state` values
int spiral_adam_step(...
                     size_t step,
                     float lr,
                     float beta1,
                     float beta2,
                     float epsilon,
                     float weight_decay,
                     bool bias_correction,
                     ...)
```

<img width="1891" alt="스크린샷 2024-04-11 오후 4 09 31" src="https://github.com/mcrl/Megatron-LM-mcrl/assets/52441827/68168996-87fc-4d37-8d45-ea9ddaeffc03">

## Other patches
- Enabled single stage run for spiral schedule

## In the upcoming commit...
- I will make parameter-wise optimizer and allow it to be enabled through argument