### PR TITLE
Enable "large" global batch size training

### DIFF
--- a/csrc/common/thread_pool.hpp
+++ b/csrc/common/thread_pool.hpp
@@ -11,7 +11,7 @@
 #include <utility>
 #include <vector>
 
-#define _DEBUG_THREAD_POOL true
+#define _DEBUG_THREAD_POOL false
 
 using namespace std;
 

--- a/csrc/common/thread_pool.hpp
+++ b/csrc/common/thread_pool.hpp
@@ -110,8 +110,9 @@ void ThreadPool::execute()
     while (_jq_size.load() == 0) {
       if (_exit)
         return;
-      printf("(pid:%ld,tid:%ld) release jqm & sleep\n", (long)getpid(),
-             (long)gettid());
+      if (_DEBUG_THREAD_POOL)
+        printf("(pid:%ld,tid:%ld) release jqm & sleep\n", (long)getpid(),
+              (long)gettid());
       _jq_has_job.wait(lck);
     }
 

--- a/csrc/common/thread_pool.hpp
+++ b/csrc/common/thread_pool.hpp
@@ -11,7 +11,7 @@
 #include <utility>
 #include <vector>
 
-#define _DEBUG_THREAD_POOL false
+#define _DEBUG_THREAD_POOL true
 
 using namespace std;
 

--- a/megatron/spiral/p2p_communication.py
+++ b/megatron/spiral/p2p_communication.py
@@ -12,6 +12,11 @@ Shape = Union[List[int], torch.Size]
 
 # Constants
 MINIMIZE_INTERNODE_COMM = False # TODO (SpiralPipe) further optimizer internode comm.
+_DEBUG_COMM = True
+
+if _DEBUG_COMM:
+    from megatron.spiral.debug import spiral_print
+
 
 # Tensor stores to use for self send-recv
 # Only used when pipeline world size is 1
@@ -220,6 +225,12 @@ def recv_input_tensor(
     if timers is not None:
         timers("recv_input_tensor").stop()
 
+    if _DEBUG_COMM:
+        if overlap_p2p_comm:
+            spiral_print(f"recv input_tensor(src={recv_rank})")
+        else:
+            spiral_print(f"recv input_tensor(src={recv_rank}, mean={torch.mean(input_tensor)})")
+
     return input_tensor, reqs
 
 
@@ -271,6 +282,9 @@ def send_output_tensor(
 
     if timers is not None:
         timers("send_output_tensor").stop()
+
+    if _DEBUG_COMM:
+        spiral_print(f"send output_tensor(dst={send_rank}, mean={torch.mean(output_tensor)})")
 
     return reqs
 
@@ -345,6 +359,12 @@ def recv_output_tensor_grad(
     if timers is not None:
         timers("output_tensor_grad").stop()
 
+    if _DEBUG_COMM:
+        if overlap_p2p_comm:
+            spiral_print(f"recv output_tensor_grad(src={recv_rank})")
+        else:
+            spiral_print(f"recv output_tensor_grad(src={recv_rank}, mean={torch.mean(output_tensor_grad)})")
+
     return output_tensor_grad, reqs
 
 
@@ -413,5 +433,8 @@ def send_input_tensor_grad(
 
     if timers is not None:
         timers("send_input_tensor_grad").stop()
+
+    if _DEBUG_COMM:
+        spiral_print(f"send input_tensor_grad(dst={send_rank}, mean={torch.mean(input_tensor_grad)})")
 
     return reqs

--- a/megatron/spiral/p2p_communication.py
+++ b/megatron/spiral/p2p_communication.py
@@ -12,7 +12,7 @@ Shape = Union[List[int], torch.Size]
 
 # Constants
 MINIMIZE_INTERNODE_COMM = False # TODO (SpiralPipe) further optimizer internode comm.
-_DEBUG_COMM = True
+_DEBUG_COMM = False
 
 if _DEBUG_COMM:
     from megatron.spiral.debug import spiral_print

--- a/megatron/spiral/schedules.py
+++ b/megatron/spiral/schedules.py
@@ -311,9 +311,9 @@ def forward_backward_pipelining_with_spiral_remap(
                         .detach()
                         .requires_grad_()
                     )
-                    assert (
-                        input_ckpt_.requires_grad
-                    ), "Input ckpt must require grad before feeding to BWD"
+                    # Input ckpt must require grad before feeding to BWD
+                    if not input_ckpt_.requires_grad:
+                        input_ckpt_.requires_grad_()
                     insert_value_to_recvs.append(input_ckpt_)
                 else:
                     if _DEBUG_SCHEDULE:

--- a/megatron/spiral/schedules.py
+++ b/megatron/spiral/schedules.py
@@ -311,9 +311,9 @@ def forward_backward_pipelining_with_spiral_remap(
                         .detach()
                         .requires_grad_()
                     )
-                    # Input ckpt must require grad before feeding to BWD
-                    if not input_ckpt_.requires_grad:
-                        input_ckpt_.requires_grad_()
+                    assert (
+                        input_ckpt_.requires_grad
+                    ), "Input ckpt must require grad before feeding to BWD"
                     insert_value_to_recvs.append(input_ckpt_)
                 else:
                     if _DEBUG_SCHEDULE:

--- a/megatron/spiral/schedules.py
+++ b/megatron/spiral/schedules.py
@@ -973,6 +973,16 @@ def forward_backward_pipelining_with_spiral(
     # Data structures for training
     forward_data_store = []
 
+    # Data structures for delayed send
+    if mpu.get_pipeline_model_parallel_rank() == mpu.get_pipeline_model_parallel_world_size() - 1:
+        NUM_DELAY_OUTPUT_TENSORS = num_microbatches - mpu.get_pipeline_model_parallel_world_size()
+        curr_delay_output_tensors = 0
+        delayed_output_tensors = []
+    if mpu.get_pipeline_model_parallel_rank() == 0:
+        NUM_DELAY_INPUT_TENSOR_GRADS = num_microbatches - mpu.get_pipeline_model_parallel_world_size()
+        curr_delay_input_tensor_grads = 0
+        delayed_input_tensor_grads = []
+
     # NOTE (SpiralPipe) forward_step() in megatron/core/pipeline_parallel/schedules.py has some additional logic to compute loss using output tensor of the last pipeline stage, which is not captured by spiral output tensors. This is a temporary workaround to capture the loss tensor, and a better solution may exist.
     if (
         not forward_only
@@ -1140,12 +1150,30 @@ def forward_backward_pipelining_with_spiral(
             ):
                 raise RuntimeError("wait_event failed")
             if not mpu.is_pipeline_last_stage():
-                _ = spiral_p2p.send_output_tensor(
-                    output_tensor,
-                    overlap_p2p_comm=overlap_p2p_comm,
-                    batch_p2p_comm=batch_p2p_comm,
-                    timers=timers,
-                )
+                if not mpu.get_pipeline_model_parallel_rank() == mpu.get_pipeline_model_parallel_world_size() - 1:
+                    # send output tensor immediately
+                    _ = spiral_p2p.send_output_tensor(
+                        output_tensor,
+                        overlap_p2p_comm=overlap_p2p_comm,
+                        batch_p2p_comm=batch_p2p_comm,
+                        timers=timers,
+                    )
+                else:
+                    # control path for only last worker
+                    # delay output tensor
+                    delayed_output_tensors.append(output_tensor)
+
+            if mpu.get_pipeline_model_parallel_rank() == mpu.get_pipeline_model_parallel_world_size() - 1:
+                if (curr_delay_output_tensors >= NUM_DELAY_OUTPUT_TENSORS):
+                    # send delayed output tensor
+                    _ = spiral_p2p.send_output_tensor(
+                        delayed_output_tensors.pop(0),
+                        overlap_p2p_comm=overlap_p2p_comm,
+                        batch_p2p_comm=batch_p2p_comm,
+                        timers=timers,
+                    )
+                else:
+                    curr_delay_output_tensors += 1
 
             torch.cuda.nvtx.range_pop()
         # end fwd microbatches
@@ -1322,12 +1350,30 @@ def forward_backward_pipelining_with_spiral(
             ):
                 raise RuntimeError("wait_event failed")
             if not mpu.is_pipeline_first_stage():
-                _ = spiral_p2p.send_input_tensor_grad(
-                    input_tensor_grad,
-                    overlap_p2p_comm=overlap_p2p_comm,
-                    batch_p2p_comm=batch_p2p_comm,
-                    timers=timers,
-                )
+                if not mpu.get_pipeline_model_parallel_rank() == 0:
+                    # send input tensor grad immediately
+                    _ = spiral_p2p.send_input_tensor_grad(
+                        input_tensor_grad,
+                        overlap_p2p_comm=overlap_p2p_comm,
+                        batch_p2p_comm=batch_p2p_comm,
+                        timers=timers,
+                    )
+                else:
+                    # control path for only first worker
+                    # delay input tensor grad
+                    delayed_input_tensor_grads.append(input_tensor_grad)
+
+            if mpu.get_pipeline_model_parallel_rank() == 0:
+                if (curr_delay_input_tensor_grads >= NUM_DELAY_INPUT_TENSOR_GRADS):
+                    # send delayed input tensor grad
+                    _ = spiral_p2p.send_input_tensor_grad(
+                        delayed_input_tensor_grads.pop(0),
+                        overlap_p2p_comm=overlap_p2p_comm,
+                        batch_p2p_comm=batch_p2p_comm,
+                        timers=timers,
+                    )
+                else:
+                    curr_delay_output_tensor_grads += 1
 
             torch.cuda.nvtx.range_pop()
         # end bwd microbatches

--- a/megatron/spiral/schedules.py
+++ b/megatron/spiral/schedules.py
@@ -388,6 +388,9 @@ def forward_backward_pipelining_with_spiral_remap(
     forward_data_store = []
 
     # Data structures for delayed send
+    # Last pipeline worker will delay sending output tensors of non-last fwd stage
+    # Last pipeline worker will delay sending input tensor grads of non-first bwd stage
+    # TODO (SpiralPipe) Refactor for cleaner code
     if mpu.get_pipeline_model_parallel_rank() == mpu.get_pipeline_model_parallel_world_size() - 1:
         NUM_DELAY_OUTPUT_TENSORS = num_microbatches - mpu.get_pipeline_model_parallel_world_size()
         NUM_DELAY_INPUT_TENSOR_GRADS = num_microbatches - mpu.get_pipeline_model_parallel_world_size()
@@ -1019,6 +1022,9 @@ def forward_backward_pipelining_with_spiral(
     forward_data_store = []
 
     # Data structures for delayed send
+    # Last pipeline worker will delay sending output tensors of non-last fwd stage
+    # First pipeline worker will delay sending input tensor grads of non-first bwd stage
+    # TODO (SpiralPipe) Refactor for cleaner code
     if mpu.get_pipeline_model_parallel_rank() == mpu.get_pipeline_model_parallel_world_size() - 1:
         NUM_DELAY_OUTPUT_TENSORS = num_microbatches - mpu.get_pipeline_model_parallel_world_size()
         curr_delay_output_tensors = 0

--- a/megatron/spiral/schedules.py
+++ b/megatron/spiral/schedules.py
@@ -387,6 +387,15 @@ def forward_backward_pipelining_with_spiral_remap(
     # Data structures for training
     forward_data_store = []
 
+    # Data structures for delayed send
+    if mpu.get_pipeline_model_parallel_rank() == mpu.get_pipeline_model_parallel_world_size() - 1:
+        NUM_DELAY_OUTPUT_TENSORS = num_microbatches - mpu.get_pipeline_model_parallel_world_size()
+        NUM_DELAY_INPUT_TENSOR_GRADS = num_microbatches - mpu.get_pipeline_model_parallel_world_size()
+        curr_delay_output_tensors = 0
+        curr_delay_input_tensor_grads = 0
+        delayed_output_tensors = []
+        delayed_input_tensor_grads = []
+
     # Event dictionaries. Key is the event tag, thus an event necessarily requires it.
     prefetch_event_queries = {}
     compute_event_queries = {}
@@ -542,13 +551,31 @@ def forward_backward_pipelining_with_spiral_remap(
             ):
                 raise RuntimeError("wait_event failed")
             if not mpu.is_pipeline_last_stage():
-                _ = spiral_p2p.send_output_tensor(
-                    output_tensor,
-                    overlap_p2p_comm=overlap_p2p_comm,
-                    batch_p2p_comm=batch_p2p_comm,
-                    timers=timers,
-                )
+                if not mpu.get_pipeline_model_parallel_rank() == mpu.get_pipeline_model_parallel_world_size() - 1:
+                    # send output tensor immediately
+                    _ = spiral_p2p.send_output_tensor(
+                        output_tensor,
+                        overlap_p2p_comm=overlap_p2p_comm,
+                        batch_p2p_comm=batch_p2p_comm,
+                        timers=timers,
+                    )
+                else:
+                    # control path for only last worker
+                    # delay output tensor
+                    delayed_output_tensors.append(output_tensor)
 
+            if mpu.get_pipeline_model_parallel_rank() == mpu.get_pipeline_model_parallel_world_size() - 1:
+                if (curr_delay_output_tensors >= NUM_DELAY_OUTPUT_TENSORS):
+                    # send delayed output tensor
+                    if (len(delayed_output_tensors) > 0):
+                        _ = spiral_p2p.send_output_tensor(
+                            delayed_output_tensors.pop(0),
+                            overlap_p2p_comm=overlap_p2p_comm,
+                            batch_p2p_comm=batch_p2p_comm,
+                            timers=timers,
+                        )
+                else:
+                    curr_delay_output_tensors += 1
             torch.cuda.nvtx.range_pop()
         # end fwd microbatches
 
@@ -734,12 +761,30 @@ def forward_backward_pipelining_with_spiral_remap(
             ):
                 raise RuntimeError("wait_event failed")
             if not mpu.is_pipeline_first_stage():
-                _ = spiral_p2p.send_input_tensor_grad(
-                    input_tensor_grad,
-                    overlap_p2p_comm=overlap_p2p_comm,
-                    batch_p2p_comm=batch_p2p_comm,
-                    timers=timers,
-                )
+                if not mpu.get_pipeline_model_parallel_rank() == mpu.get_pipeline_model_parallel_world_size() - 1:
+                    # send input tensor grad immediately
+                    _ = spiral_p2p.send_input_tensor_grad(
+                        input_tensor_grad,
+                        overlap_p2p_comm=overlap_p2p_comm,
+                        batch_p2p_comm=batch_p2p_comm,
+                        timers=timers,
+                    )
+                else:
+                    # control path for only last worker
+                    # delay input tensor grad
+                    delayed_input_tensor_grads.append(input_tensor_grad)
+
+            if mpu.get_pipeline_model_parallel_rank() == mpu.get_pipeline_model_parallel_world_size() - 1:
+                if (curr_delay_input_tensor_grads >= NUM_DELAY_INPUT_TENSOR_GRADS):
+                    if (len(delayed_input_tensor_grads) > 0):
+                        _ = spiral_p2p.send_input_tensor_grad(
+                            delayed_input_tensor_grads.pop(0),
+                            overlap_p2p_comm=overlap_p2p_comm,
+                            batch_p2p_comm=batch_p2p_comm,
+                            timers=timers,
+                        )
+                else:
+                    curr_delay_input_tensor_grads += 1
 
             torch.cuda.nvtx.range_pop()
         # end bwd microbatches

--- a/megatron/spiral/schedules.py
+++ b/megatron/spiral/schedules.py
@@ -1166,12 +1166,13 @@ def forward_backward_pipelining_with_spiral(
             if mpu.get_pipeline_model_parallel_rank() == mpu.get_pipeline_model_parallel_world_size() - 1:
                 if (curr_delay_output_tensors >= NUM_DELAY_OUTPUT_TENSORS):
                     # send delayed output tensor
-                    _ = spiral_p2p.send_output_tensor(
-                        delayed_output_tensors.pop(0),
-                        overlap_p2p_comm=overlap_p2p_comm,
-                        batch_p2p_comm=batch_p2p_comm,
-                        timers=timers,
-                    )
+                    if (len(delayed_output_tensors) > 0):
+                        _ = spiral_p2p.send_output_tensor(
+                            delayed_output_tensors.pop(0),
+                            overlap_p2p_comm=overlap_p2p_comm,
+                            batch_p2p_comm=batch_p2p_comm,
+                            timers=timers,
+                        )
                 else:
                     curr_delay_output_tensors += 1
 
@@ -1365,15 +1366,16 @@ def forward_backward_pipelining_with_spiral(
 
             if mpu.get_pipeline_model_parallel_rank() == 0:
                 if (curr_delay_input_tensor_grads >= NUM_DELAY_INPUT_TENSOR_GRADS):
-                    # send delayed input tensor grad
-                    _ = spiral_p2p.send_input_tensor_grad(
-                        delayed_input_tensor_grads.pop(0),
-                        overlap_p2p_comm=overlap_p2p_comm,
-                        batch_p2p_comm=batch_p2p_comm,
-                        timers=timers,
-                    )
+                    if (len(delayed_input_tensor_grads) > 0):
+                        # send delayed input tensor grad
+                        _ = spiral_p2p.send_input_tensor_grad(
+                            delayed_input_tensor_grads.pop(0),
+                            overlap_p2p_comm=overlap_p2p_comm,
+                            batch_p2p_comm=batch_p2p_comm,
+                            timers=timers,
+                        )
                 else:
-                    curr_delay_output_tensor_grads += 1
+                    curr_delay_input_tensor_grads += 1
 
             torch.cuda.nvtx.range_pop()
         # end bwd microbatches


### PR DESCRIPTION
## Description
Pipeline throughput is significantly dependent upon the number of microbatches trainable in a single iteration, since it increases the steady state of the pipeline schedule. This PR allows spiral pipeline schedules (both remapping and no remapping) to handle the large global batch sizes (i.e., gbs / micro batch size >> number of pipeline workers).

### Tested
On 1 and 2 nodes with following config, where MUL={2,3,4}
```
# Model spec
LAYER=48
HIDDEN=1024
HEAD=16
SEQ=1024
POS=1024

# Micro Batch size
MBS=1
GBS=$(( $MBS * $NP * $MUL ))
```