### PR TITLE
Mixed precision training 

### DIFF
--- a/csrc/spiral_helper/allocator.cpp
+++ b/csrc/spiral_helper/allocator.cpp
@@ -106,7 +106,7 @@ SpiralCPUAllocator::~SpiralCPUAllocator() {
   }
 }
 
-DataPtr SpiralCPUAllocator::allocate(size_t nbytes) const {
+DataPtr SpiralCPUAllocator::allocate(size_t nbytes) {
   void* r = const_cast<SpiralCPUAllocator*>(this)->malloc(nbytes);
   return { r, r, &local_raw_delete, at::Device(at::DeviceType::CPU) };
 }

--- a/csrc/spiral_helper/allocator.hpp
+++ b/csrc/spiral_helper/allocator.hpp
@@ -15,11 +15,11 @@ public:
   static SpiralCPUAllocator*
   instance(uintptr_t base, size_t offset, size_t size, size_t align);
 
-  DataPtr allocate(size_t nbytes) const override;
+  DataPtr allocate(size_t nbytes) override;
   void free(void* const ptr);
   at::DeleterFnPtr raw_deleter() const override;
   void* malloc(size_t nbytes);
-
+  void copy_data(void* dest, const void* src, std::size_t count) const override {}; // not implemented
   static constexpr bool debug = false; // TODO (SpiralPipe) remove when release
 
 private:

--- a/csrc/spiral_helper/comm.cpp
+++ b/csrc/spiral_helper/comm.cpp
@@ -174,7 +174,8 @@ public:
        const bool init_shmem,
        const char* shared_memory_name,
        const size_t kCpuBufferSize,
-       const size_t kCpuBufferHeaderSize);
+       const size_t kCpuBufferHeaderSize,
+       const size_t alignment);
   Comm(const Comm&) = delete;            // copy ctor
   Comm(Comm&&) = delete;                 // move ctor
   Comm& operator=(const Comm&) = delete; // copy assign
@@ -201,7 +202,7 @@ public:
 
   const py::dict GetCommInfo() const;
   template <typename T>
-  py::array_t<T>& AllGather(py::array_t<T>& fwd_arr) const;
+  void AllGather(py::array_t<T> &tgt, py::array_t<T> &src) const;
 
   inline uintptr_t GetBase(const int mpi_rank) const;
 
@@ -266,7 +267,8 @@ Comm::Comm(std::vector<int> ranks,
            const bool init_shmem,
            const char* shared_memory_name,
            const size_t kCpuBufferSize,
-           const size_t kCpuBufferHeaderSize)
+           const size_t kCpuBufferHeaderSize,
+           const size_t alignment)
 {
   if (Comm::debug)
     spdlog::info("Creating SpiralPipe Comm");
@@ -358,12 +360,11 @@ Comm::Comm(std::vector<int> ranks,
   data_ptr_ = (((char*)shared_ptr_) + kCpuBufferHeaderSize);
 
 #if __WORDSIZE == 64
-  CHECK_MPI(MPI_Allgather(&shared_ptrs_[comm_info_.mpi_rank_], 1,
-                          MPI_UNSIGNED_LONG, shared_ptrs_, 1, MPI_UNSIGNED_LONG,
-                          mpi_comm_));
+  CHECK_MPI(MPI_Allgather(&shared_ptr_, 1, MPI_UNSIGNED_LONG, shared_ptrs_, 1,
+                          MPI_UNSIGNED_LONG, mpi_comm_));
 #else
-  CHECK_MPI(MPI_Allgather(&shared_ptrs_[comm_info_.mpi_rank_], 1, MPI_UNSIGNED,
-                          shared_ptrs_, 1, MPI_UNSIGNED, mpi_comm_));
+  CHECK_MPI(MPI_Allgather(&shared_ptr_, 1, MPI_UNSIGNED, shared_ptrs_, 1,
+                          MPI_UNSIGNED, mpi_comm_));
 #endif
 
   // test
@@ -388,7 +389,7 @@ Comm::Comm(std::vector<int> ranks,
       GetBase(comm_info_.mpi_rank_),
       kCpuBufferSize / comm_info_.intra_size_ * comm_info_.intra_rank_,
       kCpuBufferSize / comm_info_.intra_size_,
-      sizeof(float)); // Shared memory is divided equally among host processes
+      alignment); // Shared memory is divided equally among host processes
 
   CHECK_MPI(MPI_Win_create(data_ptr_, kCpuBufferSize, 1, MPI_INFO_NULL,
                            MPI_COMM_WORLD, &window_));
@@ -570,14 +571,14 @@ bool Comm::IsParamDataLocal(const unsigned int param_id) const
   return param_mapping_tbl_[param_id].inter_rank_ == comm_info_.inter_rank_;
 }
 
-void Comm::SyncParamDataInfo()
-{
+void Comm::SyncParamDataInfo() {
   MPI_Barrier(MPI_COMM_WORLD);
 
   if (comm_info_.intra_rank_ == 0) {
+    assert(shared_memory_header_size_ % sizeof(unsigned long) == 0);
     CHECK_MPI(MPI_Allreduce(MPI_IN_PLACE, param_mapping_tbl_,
-                            shared_memory_header_size_, MPI_BYTE, MPI_SUM,
-                            inter_comm_));
+                            shared_memory_header_size_, MPI_UNSIGNED_CHAR,
+                            MPI_SUM, inter_comm_));
   }
 
   MPI_Barrier(MPI_COMM_WORLD);
@@ -716,16 +717,16 @@ const py::dict Comm::GetCommInfo() const
   return info;
 }
 
-template <typename T> py::array_t<T>& Comm::AllGather(py::array_t<T>& arr) const
-{
-  py::buffer_info buf = arr.request();
-  auto* ptr = (T*)arr.mutable_data();
-  py::ssize_t ag_numel = std::reduce(buf.shape.begin() + 1, buf.shape.end(), 1,
-                                     std::multiplies<>());
-  py::ssize_t ag_offset = comm_info_.mpi_rank_ * ag_numel;
-  CHECK_MPI(MPI_Allgather(&ptr[ag_offset], ag_numel, MPI_UNSIGNED, ptr,
-                          ag_numel, MPI_UNSIGNED, mpi_comm_));
-  return arr;
+template <typename T>
+void Comm::AllGather(py::array_t<T> &tgt, py::array_t<T> &src) const {
+  py::buffer_info buf = src.request();
+  py::ssize_t ag_numel =
+      std::reduce(buf.shape.begin(), buf.shape.end(), 1, std::multiplies<>());
+
+  auto *tgt_buf = (T *)tgt.mutable_data();
+  auto *src_buf = (T *)src.mutable_data();
+  CHECK_MPI(MPI_Allgather(src_buf, ag_numel, MPI_UNSIGNED, tgt_buf, ag_numel,
+                          MPI_UNSIGNED, mpi_comm_));
 }
 
 // Virtual address of allocator memory. Corrsponds to `base_` in
@@ -744,7 +745,7 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m)
         "SpiralPipeBackend LazyConfigure (C++)");
   py::class_<Comm>(m, "Comm")
       .def(py::init<std::vector<int>, const int, const bool, const char*,
-                    const size_t, const size_t>())
+                    const size_t, const size_t, const size_t>())
       .def("SetSpiralCPUAllocator", &Comm::SetSpiralCPUAllocator)
       .def("UnsetSpiralCPUAllocator", &Comm::UnsetSpiralCPUAllocator)
       .def("RemapParamData", &Comm::RemapParamData)

--- a/examples/asplos25/args.sh
+++ b/examples/asplos25/args.sh
@@ -21,6 +21,10 @@ DATA_ARGS="
     --split 949,50,1
 "
 
+MIXED_PRECISION_ARGS="
+    --fp16
+"
+
 LOGGING_ARGS="
     --log-throughput
 "

--- a/examples/asplos25/config.sh
+++ b/examples/asplos25/config.sh
@@ -17,7 +17,8 @@ done
 
 ## conda
 source ~/miniconda3/etc/profile.d/conda.sh
-conda activate spiral
+# conda activate spiral
+conda activate pytorch-2.3-cuda-12.1-python-3.8
 
 # MPI
 MPIRUN=$(which mpirun)

--- a/examples/asplos25/config.sh
+++ b/examples/asplos25/config.sh
@@ -17,7 +17,6 @@ done
 
 ## conda
 source ~/miniconda3/etc/profile.d/conda.sh
-# conda activate spiral
 conda activate pytorch-2.3-cuda-12.1-python-3.8
 
 # MPI

--- a/examples/asplos25/extra_args/spiral.sh
+++ b/examples/asplos25/extra_args/spiral.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+# --spiral-stage-optimizer \
+# --spiral-stage-optimizer-pool-size 0 \
 EXTRA_ARGS="
     --spiral \
     --spiral-remap \
@@ -9,8 +11,6 @@ EXTRA_ARGS="
     --spiral-forward-virtual-size $SPIRAL_FWD \
     --spiral-backward-virtual-size $SPIRAL_BWD \
     --spiral-overlap-offload-grad \
-    --spiral-stage-optimizer \
-    --spiral-stage-optimizer-pool-size 0 \
     --spiral-recompute-activations \
     --overlap-p2p-communication \
     --megatron-mpi

--- a/examples/asplos25/run.sh
+++ b/examples/asplos25/run.sh
@@ -40,7 +40,7 @@ if [ -n "${SPIRAL_SHMEM_NAME}" ] && [ -e "/dev/shm${SPIRAL_SHMEM_NAME}" ]; then
 fi
 
 # Configure exec cmd
-EXEC_CMD="python ${MEGATRON_PATH}/pretrain_gpt.py ${EXTRA_ARGS} ${DISTRIBUTED_ARGS} ${MODEL_ARGS} ${DATA_ARGS} ${LOGGING_ARGS}"
+EXEC_CMD="python ${MEGATRON_PATH}/pretrain_gpt.py ${EXTRA_ARGS} ${DISTRIBUTED_ARGS} ${MODEL_ARGS} ${DATA_ARGS} ${MIXED_PRECISION_ARGS} ${LOGGING_ARGS}"
 
 if [ ${NSYS_ENABLE} == "YES" ]; then
     EXEC_CMD="${NSYS} profile -t cuda,nvtx -o ${NSYS_OUTPUT}_%q{OMPI_COMM_WORLD_RANK} --force-overwrite true ${EXEC_CMD}"

--- a/examples/asplos25/run.sh
+++ b/examples/asplos25/run.sh
@@ -4,6 +4,7 @@
 #SBATCH --mincpus=4
 #SBATCH --mem=0
 #SBATCH --exclusive
+#SBATCH --gres=gpu:4
 
 ulimit -v unlimited
 
@@ -46,6 +47,6 @@ if [ ${NSYS_ENABLE} == "YES" ]; then
 fi
 
 # Run script
-${MPIRUN} -np $NP -host $HOSTS $MPI_OPTIONS ${EXEC_CMD}
+${MPIRUN} -npernode $GPUS_PER_NODE -host $HOSTS $MPI_OPTIONS ${EXEC_CMD}
 
 exit 0

--- a/megatron/arguments.py
+++ b/megatron/arguments.py
@@ -433,6 +433,9 @@ def validate_args(args, defaults={}):
                         "Warning: SpiralPipe without remapping will run with full uniform (recompute num layers=1) recomputation "
                         "regardless of --recompute-granularity, --recompute-method, and --recompute-num-layers"
                     )
+        if args.use_distributed_optimizer:
+            raise RuntimeError(
+                "SpiralPipe currently does not support distributed optimizer")
 
     # GQA
     if args.num_key_value_heads is None:

--- a/megatron/arguments.py
+++ b/megatron/arguments.py
@@ -378,9 +378,6 @@ def validate_args(args, defaults={}):
         if args.virtual_pipeline_model_parallel_size is not None:
             raise RuntimeError(
                 "SpiralPipe does not support setting virtual pipeline")
-        if args.params_dtype != torch.float:
-            raise RuntimeError(
-                "SpiralPipe only supports fp32")
         if args.lazy_mpu_init:
             raise RuntimeError(
                 "SpiralPipe does not support lazy mpu init")

--- a/megatron/initialize.py
+++ b/megatron/initialize.py
@@ -388,6 +388,7 @@ def _spiral_backend_init():
             args.spiral_shared_memory_name,
             args.spiral_shared_memory_buffer_size,
             args.spiral_shared_memory_header_size,
+            2 if (args.fp16 or args.bf16) else 4,
         )
         _set_comm_info()
 

--- a/megatron/optimizer/__init__.py
+++ b/megatron/optimizer/__init__.py
@@ -47,7 +47,7 @@ def get_param_groups(modules,
 
             if args.spiral:
                 assert (is_spiral_param(param))
-                if param.spiral_status == SpiralParamStatus.REMOTE:
+                if param.spiral_status == SpiralParamStatus.CPU:
                     param = param.spiral_tensor
 
             if no_weight_decay_cond is not None:

--- a/megatron/optimizer/__init__.py
+++ b/megatron/optimizer/__init__.py
@@ -182,8 +182,6 @@ def get_megatron_optimizer(model,
     #   from the MixedPrecisionOptimizer, which manages any optimizer where
     #   the model params and main params are distinct.
     if args.fp16 or args.bf16 or args.use_distributed_optimizer:
-        if args.spiral:
-            raise RuntimeError("SpiralPipe currently only supports FP32 optimizer.")
         # Grad scaler:
         #    if loss-scale is provided, instantiate the constant scaler.
         #    if we are using fp16 and loss-scale is not present, use a
@@ -212,15 +210,15 @@ def get_megatron_optimizer(model,
             if args.use_distributed_optimizer else \
             Float16OptimizerWithFloat16Params
         return opt_ty(optimizer,
-                      args.clip_grad,
-                      args.log_num_zeros_in_grad,
-                      params_have_main_grad,
-                      args.use_contiguous_buffers_in_local_ddp,
-                      args.fp16,
-                      args.bf16,
-                      args.params_dtype,
-                      grad_scaler,
-                      model)
+                    args.clip_grad,
+                    args.log_num_zeros_in_grad,
+                    params_have_main_grad,
+                    args.use_contiguous_buffers_in_local_ddp,
+                    args.fp16,
+                    args.bf16,
+                    args.params_dtype,
+                    grad_scaler,
+                    model)
 
     # FP32.
     return FP32Optimizer(optimizer, args.clip_grad,

--- a/megatron/optimizer/optimizer.py
+++ b/megatron/optimizer/optimizer.py
@@ -5,6 +5,8 @@
 from abc import ABC
 from abc import abstractmethod
 import warnings
+import nvtx
+
 from apex.multi_tensor_apply import multi_tensor_applier
 import amp_C
 import torch
@@ -386,7 +388,7 @@ class MixedPrecisionOptimizer(MegatronOptimizer):
     def reload_model_params(self):
         self._copy_model_params_to_main_params()
 
-
+    @nvtx.annotate("_unscale_main_grads_and_check_for_nan")
     def _unscale_main_grads_and_check_for_nan(self):
 
         # Collect main grads.
@@ -397,9 +399,11 @@ class MixedPrecisionOptimizer(MegatronOptimizer):
 
         # Unscale and set found inf/nan
         if get_args().spiral:
-            for main_grad in main_grads:
-                main_grad.mul_(self.grad_scaler.inv_scale.cpu())
-                self.found_inf.add_(self._has_inf_or_nan(main_grad))
+            # for main_grad in main_grads:
+            #     main_grad.mul_(self.grad_scaler.inv_scale.cpu())
+            #     self.found_inf.add_(self._has_inf_or_nan(main_grad))
+            torch._amp_foreach_non_finite_check_and_unscale_(
+                main_grads, self.found_inf, self.grad_scaler.inv_scale.cpu())
         else:
             torch._amp_foreach_non_finite_check_and_unscale_(
                 main_grads, self.found_inf, self.grad_scaler.inv_scale)

--- a/megatron/optimizer/optimizer.py
+++ b/megatron/optimizer/optimizer.py
@@ -4,13 +4,14 @@
 
 from abc import ABC
 from abc import abstractmethod
+import warnings
 from apex.multi_tensor_apply import multi_tensor_applier
 import amp_C
 import torch
 from torch.nn.parallel.distributed import DistributedDataParallel as torchDDP
 from torch._utils import _flatten_dense_tensors, _unflatten_dense_tensors
 
-from megatron import get_timers
+from megatron import get_timers, get_args
 from megatron import print_rank_0
 from megatron.core import mpu, tensor_parallel
 from megatron.model import DistributedDataParallel as LocalDDP
@@ -355,7 +356,10 @@ class MixedPrecisionOptimizer(MegatronOptimizer):
         # Note that we keep this for the cases that grad scaler is none.
         # We still record nan/inf if we have a bfloat16 with a grad scaler.
         if self.grad_scaler:
-            self.found_inf = torch.cuda.FloatTensor([0.0])
+            if get_args().spiral:
+                self.found_inf = torch.FloatTensor([0.0])
+            else:
+                self.found_inf = torch.cuda.FloatTensor([0.0])
 
         # Dummy tensor needed for apex multi-apply tensor.
         # For bfloat, we don't have multi-tensor apply and for now
@@ -363,7 +367,10 @@ class MixedPrecisionOptimizer(MegatronOptimizer):
         if bf16:
             self._dummy_overflow_buf = None
         else:
-            self._dummy_overflow_buf = torch.cuda.IntTensor([0])
+            if get_args().spiral:
+                self._dummy_overflow_buf = torch.IntTensor([0])
+            else:
+                self._dummy_overflow_buf = torch.cuda.IntTensor([0])
 
         # In case grad scaler is not passed, define the unity scale.
         if self.grad_scaler is None:
@@ -389,19 +396,36 @@ class MixedPrecisionOptimizer(MegatronOptimizer):
         self.found_inf.fill_(0.0)
 
         # Unscale and set found inf/nan
-        torch._amp_foreach_non_finite_check_and_unscale_(
-            main_grads, self.found_inf, self.grad_scaler.inv_scale)
+        if get_args().spiral:
+            for main_grad in main_grads:
+                main_grad.mul_(self.grad_scaler.inv_scale.cpu())
+                self.found_inf.add_(self._has_inf_or_nan(main_grad))
+        else:
+            torch._amp_foreach_non_finite_check_and_unscale_(
+                main_grads, self.found_inf, self.grad_scaler.inv_scale)
 
         # Update across all model parallel instances.
-        torch.distributed.all_reduce(self.found_inf,
-                                     op=torch.distributed.ReduceOp.MAX,
-                                     group=self.get_model_parallel_group())
+        if get_args().spiral:
+            # TODO (SpiralPipe) Implement all_reduce for found_inf
+            warnings.warn("SpiralPipe currently does not implement all_reduce for found_inf. This is a critical bug when using TP or DP with SpiralPipe. We must implement this later on.")
+        else:
+            torch.distributed.all_reduce(self.found_inf,
+                                        op=torch.distributed.ReduceOp.MAX,
+                                        group=self.get_model_parallel_group())
 
         # Check for nan.
         found_inf_flag = (self.found_inf.item() > 0)
 
         return found_inf_flag
 
+    # `x` is a torch.Tensor
+    @staticmethod
+    def _has_inf_or_nan(x, j=None):
+        float_x = x.float()
+        nan = float_x.isnan()
+        inf = float_x.isinf()
+        inf_or_nan = nan.logical_or(inf)
+        return inf_or_nan.float().max()
 
     @torch.no_grad()
     def step(self, args, timers):
@@ -519,17 +543,18 @@ class Float16OptimizerWithFloat16Params(MixedPrecisionOptimizer):
             fp32_from_float16_params_this_group = []
             # For all the parameters in this group:
             for i, param in enumerate(param_group['params']):
-                if param.requires_grad:
+                if get_args().spiral:
+                    # NOTE (SpiralPipe) cpu params do not need to require grad
 
                     # float16 params:
-                    if param.type() in ['torch.cuda.HalfTensor',
-                                        'torch.cuda.BFloat16Tensor']:
+                    if param.type() in ['torch.HalfTensor',
+                                        'torch.BFloat16Tensor']:
                         float16_params_this_group.append(param)
                         # Create a copy
                         main_param = param.detach().clone().float()
                         # Copy tensor model parallel attributes.
                         tensor_parallel.copy_tensor_model_parallel_attributes(main_param,
-                                                                              param)
+                                                                            param)
                         if hasattr(param, 'shared'):
                             main_param.shared = param.shared
                         # Replace the optimizer params with the new fp32 copy.
@@ -541,16 +566,48 @@ class Float16OptimizerWithFloat16Params(MixedPrecisionOptimizer):
                             self.optimizer.state[main_param] \
                                 = self.optimizer.state.pop(param)
                     # fp32 params.
-                    elif param.type() == 'torch.cuda.FloatTensor':
+                    elif param.type() == 'torch.FloatTensor':
                         fp32_params_this_group.append(param)
                         param_group['params'][i] = param
 
                     else:
                         raise TypeError('Wrapped parameters must be one of '
-                                        'torch.cuda.FloatTensor,  '
-                                        'torch.cuda.HalfTensor, or '
-                                        'torch.cuda.BFloat16Tensor. '
+                                        'torch.FloatTensor,  '
+                                        'torch.HalfTensor, or '
+                                        'torch.BFloat16Tensor. '
                                         'Received {}'.format(param.type()))
+                else:
+                    if param.requires_grad:
+                        # float16 params:
+                        if param.type() in ['torch.cuda.HalfTensor',
+                                            'torch.cuda.BFloat16Tensor']:
+                            float16_params_this_group.append(param)
+                            # Create a copy
+                            main_param = param.detach().clone().float()
+                            # Copy tensor model parallel attributes.
+                            tensor_parallel.copy_tensor_model_parallel_attributes(main_param,
+                                                                                param)
+                            if hasattr(param, 'shared'):
+                                main_param.shared = param.shared
+                            # Replace the optimizer params with the new fp32 copy.
+                            param_group['params'][i] = main_param
+
+                            fp32_from_float16_params_this_group.append(main_param)
+                            # Reset existing state dict key to the new main param.
+                            if param in self.optimizer.state:
+                                self.optimizer.state[main_param] \
+                                    = self.optimizer.state.pop(param)
+                        # fp32 params.
+                        elif param.type() == 'torch.cuda.FloatTensor':
+                            fp32_params_this_group.append(param)
+                            param_group['params'][i] = param
+
+                        else:
+                            raise TypeError('Wrapped parameters must be one of '
+                                            'torch.cuda.FloatTensor,  '
+                                            'torch.cuda.HalfTensor, or '
+                                            'torch.cuda.BFloat16Tensor. '
+                                            'Received {}'.format(param.type()))
 
             self.float16_groups.append(float16_params_this_group)
             self.fp32_from_float16_groups.append(

--- a/megatron/spiral/init_context.py
+++ b/megatron/spiral/init_context.py
@@ -400,7 +400,7 @@ class SpiralInitContext(InsertPostInitMethodToModuleSubClasses):
         InsertPostInitMethodToModuleSubClasses.num_spiral_elements += param.numel()
 
         param.spiral_id = sbs.get_add_spiral_next_param_number_to_build()
-        param.spiral_status = SpiralParamStatus.ACTIVE
+        param.spiral_status = SpiralParamStatus.GPU
         param.spiral_shape = param.shape
         param.spiral_stride = param.stride()
         param.spiral_storage_offset = param.storage_offset()
@@ -416,13 +416,13 @@ class SpiralInitContext(InsertPostInitMethodToModuleSubClasses):
             """Free weight data of a parameter."""
             param.data = torch.empty(0, dtype=param.dtype, device=param.device)
             if param.spiral_tensor.numel() == param.spiral_numel:
-                param.spiral_status = SpiralParamStatus.REMOTE
+                param.spiral_status = SpiralParamStatus.CPU
             else:
                 param.spiral_status = SpiralParamStatus.UNAVAILABLE
 
         def _offload_data(param, non_blocking=False):
             """Offload weight data of a parameter to remote device."""
-            assert param.spiral_status == SpiralParamStatus.ACTIVE
+            assert param.spiral_status == SpiralParamStatus.GPU
             assert param.spiral_tensor is not None, "Offload tensor is None"
 
             if param.spiral_tensor.numel() == 0:
@@ -444,10 +444,10 @@ class SpiralInitContext(InsertPostInitMethodToModuleSubClasses):
                 param.spiral_tensor.copy_(param.data, non_blocking=non_blocking)
             if not non_blocking:
                 # NOTE: for non-blocking offload, spiral_status should be changed after waiting in the caller
-                param.spiral_status = SpiralParamStatus.REMOTE
+                param.spiral_status = SpiralParamStatus.CPU
 
         def _fetch_data(param, non_blocking=False):
-            assert param.spiral_status == SpiralParamStatus.REMOTE
+            assert param.spiral_status == SpiralParamStatus.CPU
             assert param.spiral_tensor is not None, "Fetch tensor is None"
 
             if param.numel() == 0:
@@ -477,7 +477,7 @@ class SpiralInitContext(InsertPostInitMethodToModuleSubClasses):
                     )
             if not non_blocking:
                 # NOTE: for non-blocking fetch, spiral_status should be changed after waiting in the caller
-                param.spiral_status = SpiralParamStatus.ACTIVE
+                param.spiral_status = SpiralParamStatus.GPU
 
         def _offload_grad(param, non_blocking=False):
             """Offload a gradient to remote device."""
@@ -652,7 +652,7 @@ class SpiralInitContext(InsertPostInitMethodToModuleSubClasses):
                         param.spiral_storage_offset,
                     )
                     if param.spiral_status == SpiralParamStatus.UNAVAILABLE:
-                        param.spiral_status = SpiralParamStatus.REMOTE
+                        param.spiral_status = SpiralParamStatus.CPU
         else:
             for param in module.parameters(recurse=True):
                 if is_spiral_param(param):

--- a/megatron/spiral/init_context.py
+++ b/megatron/spiral/init_context.py
@@ -456,7 +456,7 @@ class SpiralInitContext(InsertPostInitMethodToModuleSubClasses):
                         device=self.local_device, non_blocking=non_blocking
                     ).view(param.spiral_shape)
                 else:
-                    param.data = torch.empty(param.spiral_shape, device=self.local_device)
+                    param.data = torch.empty(param.spiral_shape, device=self.local_device, dtype=param.dtype)
                     get_thunder_group().FetchRemoteParam(
                         param.spiral_id,
                         non_blocking,
@@ -469,7 +469,7 @@ class SpiralInitContext(InsertPostInitMethodToModuleSubClasses):
                 if not get_args().spiral_remap or get_thunder_group().IsParamDataLocal(param.spiral_id):
                     param.data.copy_(param.spiral_tensor, non_blocking=non_blocking)
                 else:
-                    param.data = torch.empty(param.spiral_shape, device=self.local_device)
+                    param.data = torch.empty(param.spiral_shape, device=self.local_device, dtype=param.dtype)
                     get_thunder_group().FetchRemoteParam(
                         param.spiral_id,
                         non_blocking,

--- a/megatron/spiral/init_context.py
+++ b/megatron/spiral/init_context.py
@@ -38,10 +38,10 @@ _orig_torch_randn = torch.randn
 
 class SpiralParamStatus(Enum):
     # parameter is fully present on local device and ready for use
-    ACTIVE = 1
+    GPU = 1
 
     # parameter is in CPU
-    REMOTE = 2
+    CPU = 2
 
     # parameter is not available
     UNAVAILABLE = 3

--- a/megatron/spiral/initialize.py
+++ b/megatron/spiral/initialize.py
@@ -19,6 +19,7 @@ class SpiralBackend:
         shared_memory_name,
         shared_memory_buffer_size,
         shared_memory_header_size,
+        alignment,
     ):
         self.thunder_group = spiral_helper.Comm(
             sorted(ranks),
@@ -27,6 +28,7 @@ class SpiralBackend:
             shared_memory_name,
             shared_memory_buffer_size,
             shared_memory_header_size,
+            alignment,
         )
         self.thunder_cuda_manager = SpiralCUDAManager()
         global SPIRAL_BACKEND

--- a/megatron/spiral/schedules.py
+++ b/megatron/spiral/schedules.py
@@ -425,7 +425,7 @@ def forward_backward_pipelining_with_spiral_remap(
             "compute",
             tag="prefetch:f0",
             post_wait_fn=lambda: _post_wait_set_spiral_param_status(
-                model[0], SpiralParamStatus.ACTIVE
+                model[0], SpiralParamStatus.GPU
             ),
         )
         if get_thunder_cuda_manager().record_event(prefetch_f0) == -1:
@@ -468,7 +468,7 @@ def forward_backward_pipelining_with_spiral_remap(
                     "compute",
                     tag=tag,
                     post_wait_fn=lambda fwd_stage_id=fwd_stage_id: _post_wait_set_spiral_param_status(
-                        model[fwd_stage_id + 1], SpiralParamStatus.ACTIVE
+                        model[fwd_stage_id + 1], SpiralParamStatus.GPU
                     ),
                 )
                 if get_thunder_cuda_manager().record_event(prefetch_next) == -1:
@@ -601,7 +601,7 @@ def forward_backward_pipelining_with_spiral_remap(
                     "prefetch",
                     tag=f"free:f{fwd_stage_id}",
                     post_wait_fn=lambda fwd_stage_id=fwd_stage_id: _post_wait_set_spiral_param_status(
-                        model[fwd_stage_id], SpiralParamStatus.REMOTE
+                        model[fwd_stage_id], SpiralParamStatus.CPU
                     ),
                 )
                 if get_thunder_cuda_manager().record_event(free_curr) == -1:
@@ -651,7 +651,7 @@ def forward_backward_pipelining_with_spiral_remap(
                     "compute",
                     tag="prefetch:" + f"b{bwd_stage_id - 1}",
                     post_wait_fn=lambda bwd_stage_id=bwd_stage_id: _post_wait_set_spiral_param_status(
-                        model[-bwd_stage_id], SpiralParamStatus.ACTIVE
+                        model[-bwd_stage_id], SpiralParamStatus.GPU
                     ),
                 )
                 if get_thunder_cuda_manager().record_event(prefetch_next) == -1:
@@ -807,7 +807,7 @@ def forward_backward_pipelining_with_spiral_remap(
                 None if bwd_stage_id == 0 else "prefetch",
                 tag=f"free:b{bwd_stage_id}",
                 post_wait_fn=lambda bwd_stage_id=bwd_stage_id: _post_wait_set_spiral_param_status(
-                    model[-bwd_stage_id - 1], SpiralParamStatus.REMOTE
+                    model[-bwd_stage_id - 1], SpiralParamStatus.CPU
                 ),
             )
             if get_thunder_cuda_manager().record_event(free_curr) == -1:
@@ -1073,7 +1073,7 @@ def forward_backward_pipelining_with_spiral(
             "compute",
             tag="prefetch:f0",
             post_wait_fn=lambda: _post_wait_set_spiral_param_status(
-                model[0], SpiralParamStatus.ACTIVE
+                model[0], SpiralParamStatus.GPU
             ),
         )
         if get_thunder_cuda_manager().record_event(prefetch_f0) == -1:
@@ -1109,7 +1109,7 @@ def forward_backward_pipelining_with_spiral(
                     "compute",
                     tag=tag,
                     post_wait_fn=lambda fwd_stage_id=fwd_stage_id: _post_wait_set_spiral_param_status(
-                        model[fwd_stage_id + 1], SpiralParamStatus.ACTIVE
+                        model[fwd_stage_id + 1], SpiralParamStatus.GPU
                     ),
                 )
                 if get_thunder_cuda_manager().record_event(prefetch_next) == -1:
@@ -1252,7 +1252,7 @@ def forward_backward_pipelining_with_spiral(
                     "prefetch",
                     tag=f"free:f{fwd_stage_id}",
                     post_wait_fn=lambda fwd_stage_id=fwd_stage_id: _post_wait_set_spiral_param_status(
-                        model[fwd_stage_id], SpiralParamStatus.REMOTE
+                        model[fwd_stage_id], SpiralParamStatus.CPU
                     ),
                 )
                 if get_thunder_cuda_manager().record_event(free_curr) == -1:
@@ -1297,7 +1297,7 @@ def forward_backward_pipelining_with_spiral(
                     "compute",
                     tag="prefetch:" + f"b{bwd_stage_id - 1}",
                     post_wait_fn=lambda bwd_stage_id=bwd_stage_id: _post_wait_set_spiral_param_status(
-                        model[bwd_stage_id - 1], SpiralParamStatus.ACTIVE
+                        model[bwd_stage_id - 1], SpiralParamStatus.GPU
                     ),
                 )
                 if get_thunder_cuda_manager().record_event(prefetch_next) == -1:
@@ -1452,7 +1452,7 @@ def forward_backward_pipelining_with_spiral(
                 None if bwd_stage_id == 0 else "prefetch",
                 tag=f"free:b{bwd_stage_id}",
                 post_wait_fn=lambda bwd_stage_id=bwd_stage_id: _post_wait_set_spiral_param_status(
-                    model[bwd_stage_id], SpiralParamStatus.REMOTE
+                    model[bwd_stage_id], SpiralParamStatus.CPU
                 ),
             )
             if get_thunder_cuda_manager().record_event(free_curr) == -1:

--- a/megatron/training.py
+++ b/megatron/training.py
@@ -380,6 +380,11 @@ def get_model(model_provider_func, model_type=ModelType.encoder_or_decoder, wrap
             )
             this_model.model_type = model_type
 
+            # wrap model with Float16Module
+            if args.fp16 or args.bf16:
+                with SpiralWrapperInitContext(enabled=True):
+                    this_model = Float16Module(this_model, args)
+
             # reset states of the callee
             if mpu.is_spiral_forward_stage():
                 sbs.set_spiral_forward_stage_build_phase(None)
@@ -625,7 +630,10 @@ def get_model(model_provider_func, model_type=ModelType.encoder_or_decoder, wrap
         model_module.cuda(torch.cuda.current_device())
 
     # Fp16 conversion.
-    if args.fp16 or args.bf16:
+    # NOTE (SpiralPipe) Wrapping GPTModel into fp16 module is done in `_model_provider_func_wrapper`
+    if args.spiral:
+        pass
+    elif args.fp16 or args.bf16:
         model = [Float16Module(model_module, args) for model_module in model]
 
     if wrap_with_ddp:

--- a/megatron/training.py
+++ b/megatron/training.py
@@ -440,11 +440,11 @@ def get_model(model_provider_func, model_type=ModelType.encoder_or_decoder, wrap
                 ),
                 dtype=np.uintc,
             )
-            num_params_per_fwd_build_phase[mpu.get_pipeline_model_parallel_rank()] = [
+            num_params_per_fwd_build_phase_per_rank = np.array([
                 [m.num_spiral_params_recurse for m in __stage_models.module_list]
                 for __stage_models in model[:mpu.get_spiral_forward_virtual_size()]
-            ]
-            num_params_per_fwd_build_phase = get_thunder_group().AllGather(num_params_per_fwd_build_phase)
+            ])
+            get_thunder_group().AllGather(num_params_per_fwd_build_phase, num_params_per_fwd_build_phase_per_rank) # (tgt,src)
             __phase = 0
             __phase_nparam_dict = {}
             for i in range(mpu.get_spiral_forward_virtual_size()):

--- a/megatron/training.py
+++ b/megatron/training.py
@@ -548,9 +548,13 @@ def get_model(model_provider_func, model_type=ModelType.encoder_or_decoder, wrap
             for stage_model in model:
                 for param in stage_model.parameters(recurse=True):
                     if is_spiral_param(param):
-                        if mpu.is_spiral_remap() and get_thunder_group().IsParamDataLocal(param.spiral_id):
-                            continue
-                        assert getattr(param, "spiral_tensor").is_pinned(), f"{debug_param2name_id(param)} on local node is not pinned."
+                        if (
+                            mpu.is_spiral_remap()
+                            and get_thunder_group().IsParamDataLocal(param.spiral_id)
+                        ):
+                            assert getattr(
+                                param, "spiral_tensor"
+                            ).is_pinned(), f"{debug_param2name_id(param)} on local node is not pinned."
 
         if mpu.is_spiral_remap():
             get_thunder_group().UnsetSpiralCPUAllocator()


### PR DESCRIPTION
ENV upgrade: PyTorch 2.3 + CUDA 12.1 + Python 3.0
- PyTorch >= 2.3 is required for amp gradient unscale CPU kernel

For spiral, GPTModel is wrapped with Float16Module to cast/uncast input.
Float16Optimizer mostly does the magic. Modified original code that only works on cuda tensors to handle CPU tensors. 

SpiralStageOptimizer is not yet ported. 
Also, left one misc TODO in megatron/optimizer/optimizer.py. Left it because CPU tensors (found_inf) can't be allreduced with group on nccl backend.
```
        # Update across all model parallel instances.
        if get_args().spiral:
            # TODO (SpiralPipe) Implement all_reduce for found_inf
            warnings.warn("SpiralPipe currently does not implement all_reduce for found_inf. This is a critical bug when using TP or DP with SpiralPipe. We must implement this later on.")
        else:
            torch.distributed.all_reduce(self.found_inf,
                                        op=torch.distributed.ReduceOp.MAX,
                                        group=self.get_model_parallel_group())
```

 