### PR TITLE
Cross mapping

### DIFF
--- a/examples/asplos25/extra_args/spiral.sh
+++ b/examples/asplos25/extra_args/spiral.sh
@@ -12,6 +12,7 @@ EXTRA_ARGS="
     --spiral-backward-virtual-size $SPIRAL_BWD \
     --spiral-overlap-offload-grad \
     --spiral-recompute-activations \
+    --spiral-cross-mapping \
     --overlap-p2p-communication \
     --megatron-mpi
 "

--- a/megatron/arguments.py
+++ b/megatron/arguments.py
@@ -436,6 +436,10 @@ def validate_args(args, defaults={}):
         if args.use_distributed_optimizer:
             raise RuntimeError(
                 "SpiralPipe currently does not support distributed optimizer")
+        if args.spiral_cross_mapping:
+            if args.spiral_forward_virtual_size != args.spiral_backward_virtual_size:
+                raise RuntimeError(
+                    "SpiralPipe with cross mapping requires forward and backward virtual size to be the same")
 
     # GQA
     if args.num_key_value_heads is None:
@@ -1112,6 +1116,8 @@ def _add_distributed_args(parser):
                         'Default value (0) enables dynamic thread pool sizing')
     group.add_argument('--spiral-debug-backend', action='store_true',
                        help='Enable SpiralPipe backend logging')
+    group.add_argument('--spiral-cross-mapping', action='store_true',
+                       help='Enable SpiralPipe cross-mapping')
 
     return parser
 

--- a/megatron/core/parallel_state.py
+++ b/megatron/core/parallel_state.py
@@ -69,11 +69,13 @@ _SPIRAL_FORWARD_VIRTUAL_SIZE = None
 _SPIRAL_BACKWARD_VIRTUAL_SIZE = None
 
 # SpiralPipe cross mapping
-# if pp rank = 0..3 is cross-mapped into cm rank = 3,1,2,0
-# cross_mapping_list=[3,1,2,0] and cross_mapping_dict={0:3, 1:1, 2:2, 3:0}
+# spiral cross mapping rank list: idx - cm rank, element - pp rank
+# spiral cross mapping cm rank to pp rank dict: { cm rank: pp rank }
+# spiral cross mapping pp rank to cm rank dict: { pp rank: cm rank }
 _SPIRAL_CROSS_MAPPING = None
 _SPIRAL_CROSS_MAPPING_LIST = None
-_SPIRAL_CROSS_MAPPING_DICT = None
+_SPIRAL_CROSS_MAPPING_CM_RANK_TO_PP_RANK_DICT = None
+_SPIRAL_CROSS_MAPPING_PP_RANK_TO_CM_RANK_DICT = None
 
 # Below SpiralPipe variables are lazily set after spiral backend init using CommInfo
 _SPIRAL_INTRA_SIZE = None
@@ -293,10 +295,11 @@ def initialize_model_parallel(
         if rank in ranks:
             if _SPIRAL_CROSS_MAPPING:
                 global _SPIRAL_CROSS_MAPPING_LIST
-                global _SPIRAL_CROSS_MAPPING_DICT
-                # TODO (SpiralPipe) currently assumes nprocs_per_node =4 and stride=2
-                _SPIRAL_CROSS_MAPPING_LIST = spiral_cross_mapping_pattern(list(ranks), len(ranks) // 4, 2)
-                _SPIRAL_CROSS_MAPPING_DICT = {pp_rank: cm_rank for cm_rank, pp_rank in enumerate(_SPIRAL_CROSS_MAPPING_LIST)}
+                global _SPIRAL_CROSS_MAPPING_CM_RANK_TO_PP_RANK_DICT
+                global _SPIRAL_CROSS_MAPPING_PP_RANK_TO_CM_RANK_DICT
+                _SPIRAL_CROSS_MAPPING_LIST = apply_spiral_cross_mapping(list(ranks))
+                _SPIRAL_CROSS_MAPPING_CM_RANK_TO_PP_RANK_DICT = {cm_rank: pp_rank for cm_rank, pp_rank in enumerate(_SPIRAL_CROSS_MAPPING_LIST)}
+                _SPIRAL_CROSS_MAPPING_PP_RANK_TO_CM_RANK_DICT = {pp_rank: cm_rank for cm_rank, pp_rank in enumerate(_SPIRAL_CROSS_MAPPING_LIST)}
 
         # Setup embedding group (to exchange gradients between
         # first and last stages).
@@ -562,9 +565,17 @@ def get_pipeline_model_parallel_rank():
     else:
         rank = torch.distributed.get_rank(group=get_pipeline_model_parallel_group())
     if _SPIRAL_CROSS_MAPPING:
-        assert _SPIRAL_CROSS_MAPPING_DICT is not None
-        rank = _SPIRAL_CROSS_MAPPING_DICT[rank]
+        assert _SPIRAL_CROSS_MAPPING_PP_RANK_TO_CM_RANK_DICT is not None
+        rank = _SPIRAL_CROSS_MAPPING_PP_RANK_TO_CM_RANK_DICT[rank]
     return rank
+
+
+def translate_cm_rank_to_pp_rank(cm_rank):
+    """Return the pp_rank of the cm_rank. Generally used to translate back before
+    communication calls using pp_rank based groups"""
+    assert _SPIRAL_CROSS_MAPPING
+    assert _SPIRAL_CROSS_MAPPING_CM_RANK_TO_PP_RANK_DICT is not None
+    return _SPIRAL_CROSS_MAPPING_CM_RANK_TO_PP_RANK_DICT[cm_rank]
 
 
 def get_pipeline_model_parallel_split_rank():
@@ -983,12 +994,24 @@ def destroy_model_parallel():
     _SPIRAL_CROSS_MAPPING = None
     global _SPIRAL_CROSS_MAPPING_LIST
     _SPIRAL_CROSS_MAPPING_LIST = None
-    global _SPIRAL_CROSS_MAPPING_DICT
-    _SPIRAL_CROSS_MAPPING_DICT = None
+    global _SPIRAL_CROSS_MAPPING_CM_RANK_TO_PP_RANK_DICT
+    _SPIRAL_CROSS_MAPPING_CM_RANK_TO_PP_RANK_DICT = None
+    global _SPIRAL_CROSS_MAPPING_PP_RANK_TO_CM_RANK_DICT
+    _SPIRAL_CROSS_MAPPING_PP_RANK_TO_CM_RANK_DICT = None
 
 
-def spiral_cross_mapping_pattern(ranks, nnodes, stride):
-    nprocs_per_node = len(ranks) // nnodes
+def apply_spiral_cross_mapping(ranks):
+    """ Converts sorted pp rank list into list whose index is cm_rank and element is pp_rank.
+    Maps into pattern which elimiates inter-node fetch (when fvs==bvs) and minimizes intra-node activation comm.
+
+    TODO (SpiralPipe) currently assumes nprocs_per_node=4 and stride=2
+    """
+    assert ranks == sorted(ranks), "pp rank list must be sorted before appy cross mapping"
+
+    nprocs_per_node = 4
+    nnodes =  len(ranks) // nprocs_per_node
+    stride = 2 # except the first and last process, `stride` processes of a node are sequentially mapped to cm_ranks
+
     ret = []
     for i in range(nprocs_per_node // stride):
         r = range(nnodes) if i % 2 == 0 else range(nnodes-1, -1, -1)

--- a/megatron/core/parallel_state.py
+++ b/megatron/core/parallel_state.py
@@ -866,6 +866,7 @@ def get_pipeline_model_parallel_prev_rank():
     else:
         assert _PIPELINE_GLOBAL_RANKS is not None, \
             "Pipeline parallel group is not initialized"
+        return _PIPELINE_GLOBAL_RANKS[(rank_in_pipeline - 1) % world_size]
 
 
 def get_data_parallel_world_size():

--- a/megatron/core/parallel_state.py
+++ b/megatron/core/parallel_state.py
@@ -2,6 +2,8 @@
 
 """Model and data parallel groups."""
 
+import warnings
+
 import torch
 from typing import Optional
 
@@ -66,6 +68,13 @@ _SPIRAL_BACKWARD_VIRTUAL_RANK = None # should set rank value only when active
 _SPIRAL_FORWARD_VIRTUAL_SIZE = None
 _SPIRAL_BACKWARD_VIRTUAL_SIZE = None
 
+# SpiralPipe cross mapping
+# if pp rank = 0..3 is cross-mapped into cm rank = 3,1,2,0
+# cross_mapping_list=[3,1,2,0] and cross_mapping_dict={0:3, 1:1, 2:2, 3:0}
+_SPIRAL_CROSS_MAPPING = None
+_SPIRAL_CROSS_MAPPING_LIST = None
+_SPIRAL_CROSS_MAPPING_DICT = None
+
 # Below SpiralPipe variables are lazily set after spiral backend init using CommInfo
 _SPIRAL_INTRA_SIZE = None
 _SPIRAL_INTRA_RANK = None
@@ -81,6 +90,7 @@ def initialize_model_parallel(
     spiral_remap: bool = False,
     spiral_forward_virtual_size: Optional[int] = None,
     spiral_backward_virtual_size: Optional[int] = None,
+    spiral_cross_mapping: bool = False,
     use_fp8: bool = False,
 ) -> None:
     """Initialize model data parallel groups.
@@ -198,10 +208,13 @@ def initialize_model_parallel(
             _SPIRAL_FORWARD_VIRTUAL_SIZE = spiral_forward_virtual_size
         if spiral_backward_virtual_size is not None:
             _SPIRAL_BACKWARD_VIRTUAL_SIZE = spiral_backward_virtual_size
+        global _SPIRAL_CROSS_MAPPING
+        _SPIRAL_CROSS_MAPPING = spiral_cross_mapping
 
     if pipeline_model_parallel_split_rank is not None:
         global _PIPELINE_MODEL_PARALLEL_SPLIT_RANK
         _PIPELINE_MODEL_PARALLEL_SPLIT_RANK = pipeline_model_parallel_split_rank
+        warnings.warn("SpiralPipe cross mapping currently does not consider pipeline_model_parallel_split_rank. Consequencies are unknown.")
 
     rank = torch.distributed.get_rank()
 
@@ -275,6 +288,16 @@ def initialize_model_parallel(
         if rank in ranks:
             _PIPELINE_MODEL_PARALLEL_GROUP = group
             _PIPELINE_GLOBAL_RANKS = ranks
+
+        # Setup spiral cross mapping
+        if rank in ranks:
+            if _SPIRAL_CROSS_MAPPING:
+                global _SPIRAL_CROSS_MAPPING_LIST
+                global _SPIRAL_CROSS_MAPPING_DICT
+                # TODO (SpiralPipe) currently assumes nprocs_per_node =4 and stride=2
+                _SPIRAL_CROSS_MAPPING_LIST = spiral_cross_mapping_pattern(list(ranks), len(ranks) // 4, 2)
+                _SPIRAL_CROSS_MAPPING_DICT = {pp_rank: cm_rank for cm_rank, pp_rank in enumerate(_SPIRAL_CROSS_MAPPING_LIST)}
+
         # Setup embedding group (to exchange gradients between
         # first and last stages).
         if len(ranks) > 1:
@@ -289,8 +312,12 @@ def initialize_model_parallel(
                     position_embedding_ranks = [ranks[0],
                                        ranks[pipeline_model_parallel_split_rank]]
             if _SPIRAL and _SPIRAL_REMAP:
-                spiral_embedding_ranks = [ranks[0], ranks[-1]]
-                spiral_position_embedding_ranks = [ranks[0], ranks[-1]] # since forward and backward both have a prep stage
+                if _SPIRAL_CROSS_MAPPING:
+                    spiral_embedding_ranks = [_SPIRAL_CROSS_MAPPING_LIST[0], _SPIRAL_CROSS_MAPPING_LIST[-1]]
+                    spiral_position_embedding_ranks = [_SPIRAL_CROSS_MAPPING_LIST[0], _SPIRAL_CROSS_MAPPING_LIST[-1]] # since forward and backward both have a prep stage
+                else:
+                    spiral_embedding_ranks = [ranks[0], ranks[-1]]
+                    spiral_position_embedding_ranks = [ranks[0], ranks[-1]] # since forward and backward both have a prep stage
         else:
             embedding_ranks = ranks
             position_embedding_ranks = ranks
@@ -298,6 +325,7 @@ def initialize_model_parallel(
             if _SPIRAL and _SPIRAL_REMAP:
                 spiral_embedding_ranks = ranks
                 spiral_position_embedding_ranks = ranks
+                # no need to have separate control flow for spiral cross mapping
 
         group = torch.distributed.new_group(embedding_ranks)
         if rank in embedding_ranks:
@@ -528,9 +556,15 @@ def get_tensor_model_parallel_rank():
 def get_pipeline_model_parallel_rank():
     """Return my rank for the pipeline model parallel group."""
     global _MPU_PIPELINE_MODEL_PARALLEL_RANK
+    rank = None
     if _MPU_PIPELINE_MODEL_PARALLEL_RANK is not None:
-        return _MPU_PIPELINE_MODEL_PARALLEL_RANK
-    return torch.distributed.get_rank(group=get_pipeline_model_parallel_group())
+        rank = _MPU_PIPELINE_MODEL_PARALLEL_RANK
+    else:
+        rank = torch.distributed.get_rank(group=get_pipeline_model_parallel_group())
+    if _SPIRAL_CROSS_MAPPING:
+        assert _SPIRAL_CROSS_MAPPING_DICT is not None
+        rank = _SPIRAL_CROSS_MAPPING_DICT[rank]
+    return rank
 
 
 def get_pipeline_model_parallel_split_rank():
@@ -669,6 +703,15 @@ def is_spiral_remap():
     return _SPIRAL and _SPIRAL_REMAP
 
 
+def is_spiral_cross_mapping():
+    """Return true if SpiralPipe cross mapping is enabled"""
+    if _SPIRAL is None:
+        return False
+    if _SPIRAL_CROSS_MAPPING is None:
+        return False
+    return _SPIRAL and _SPIRAL_CROSS_MAPPING
+
+
 def is_spiral_forward_stage():
     """Return true if current stage is a forward stage in SpiralPipe."""
     if not _SPIRAL:
@@ -768,35 +811,50 @@ def get_data_parallel_src_rank():
 def get_pipeline_model_parallel_first_rank():
     """Return the global rank of the first process in the pipeline for the
     current tensor parallel group"""
-    assert _PIPELINE_GLOBAL_RANKS is not None, \
-        "Pipeline parallel group is not initialized"
-    return _PIPELINE_GLOBAL_RANKS[0]
+    if _SPIRAL_CROSS_MAPPING:
+        assert _SPIRAL_CROSS_MAPPING_LIST is not None
+        return _SPIRAL_CROSS_MAPPING_LIST[0]
+    else:
+        assert _PIPELINE_GLOBAL_RANKS is not None, \
+            "Pipeline parallel group is not initialized"
+        return _PIPELINE_GLOBAL_RANKS[0]
 
 
 def get_pipeline_model_parallel_last_rank():
     """Return the global rank of the last process in the pipeline for the
     current tensor parallel group"""
-    assert _PIPELINE_GLOBAL_RANKS is not None, \
-        "Pipeline parallel group is not initialized"
-    last_rank_local = get_pipeline_model_parallel_world_size() - 1
-    return _PIPELINE_GLOBAL_RANKS[last_rank_local]
+    if _SPIRAL_CROSS_MAPPING:
+        assert _SPIRAL_CROSS_MAPPING_LIST is not None
+        return _SPIRAL_CROSS_MAPPING_LIST[-1]
+    else:
+        assert _PIPELINE_GLOBAL_RANKS is not None, \
+            "Pipeline parallel group is not initialized"
+        last_rank_local = get_pipeline_model_parallel_world_size() - 1
+        return _PIPELINE_GLOBAL_RANKS[last_rank_local]
 
 def get_pipeline_model_parallel_next_rank():
     """Return the global rank that follows the caller in the pipeline"""
-    assert _PIPELINE_GLOBAL_RANKS is not None, \
-        "Pipeline parallel group is not initialized"
     rank_in_pipeline = get_pipeline_model_parallel_rank()
     world_size = get_pipeline_model_parallel_world_size()
-    return _PIPELINE_GLOBAL_RANKS[(rank_in_pipeline + 1) % world_size]
+    if _SPIRAL_CROSS_MAPPING:
+        assert _SPIRAL_CROSS_MAPPING_LIST is not None
+        return _SPIRAL_CROSS_MAPPING_LIST[(rank_in_pipeline + 1) % world_size]
+    else:
+        assert _PIPELINE_GLOBAL_RANKS is not None, \
+            "Pipeline parallel group is not initialized"
+        return _PIPELINE_GLOBAL_RANKS[(rank_in_pipeline + 1) % world_size]
 
 
 def get_pipeline_model_parallel_prev_rank():
     """Return the global rank that preceeds the caller in the pipeline"""
-    assert _PIPELINE_GLOBAL_RANKS is not None, \
-        "Pipeline parallel group is not initialized"
     rank_in_pipeline = get_pipeline_model_parallel_rank()
     world_size = get_pipeline_model_parallel_world_size()
-    return _PIPELINE_GLOBAL_RANKS[(rank_in_pipeline - 1) % world_size]
+    if _SPIRAL_CROSS_MAPPING:
+        assert _SPIRAL_CROSS_MAPPING_LIST is not None
+        return _SPIRAL_CROSS_MAPPING_LIST[(rank_in_pipeline - 1) % world_size]
+    else:
+        assert _PIPELINE_GLOBAL_RANKS is not None, \
+            "Pipeline parallel group is not initialized"
 
 
 def get_data_parallel_world_size():
@@ -920,3 +978,23 @@ def destroy_model_parallel():
     _SPIRAL_EMBEDDING_GLOBAL_RANKS = None
     global _SPIRAL_POSITION_EMBEDDING_GLOBAL_RANKS
     _SPIRAL_POSITION_EMBEDDING_GLOBAL_RANKS = None
+
+    global _SPIRAL_CROSS_MAPPING
+    _SPIRAL_CROSS_MAPPING = None
+    global _SPIRAL_CROSS_MAPPING_LIST
+    _SPIRAL_CROSS_MAPPING_LIST = None
+    global _SPIRAL_CROSS_MAPPING_DICT
+    _SPIRAL_CROSS_MAPPING_DICT = None
+
+
+def spiral_cross_mapping_pattern(ranks, nnodes, stride):
+    nprocs_per_node = len(ranks) // nnodes
+    ret = []
+    for i in range(nprocs_per_node // stride):
+        r = range(nnodes) if i % 2 == 0 else range(nnodes-1, -1, -1)
+        for j in r:
+            for k in range(stride):
+                idx = stride*i + j*nprocs_per_node + k
+                # print(f"{i=} {j=} {k=} {idx=}")
+                ret.append(ranks[idx])
+    return ret

--- a/megatron/initialize.py
+++ b/megatron/initialize.py
@@ -206,7 +206,8 @@ def _initialize_distributed():
                                           args.spiral,
                                           args.spiral_remap,
                                           args.spiral_forward_virtual_size,
-                                          args.spiral_backward_virtual_size,)
+                                          args.spiral_backward_virtual_size,
+                                          args.spiral_cross_mapping,)
             if args.rank == 0:
                 print(f'> initialized tensor model parallel with size '
                       f'{mpu.get_tensor_model_parallel_world_size()}')

--- a/megatron/spiral/init_context.py
+++ b/megatron/spiral/init_context.py
@@ -457,6 +457,7 @@ class SpiralInitContext(InsertPostInitMethodToModuleSubClasses):
                     ).view(param.spiral_shape)
                 else:
                     param.data = torch.empty(param.spiral_shape, device=self.local_device, dtype=param.dtype)
+                    assert not get_args().spiral_cross_mapping, "Spiral cross mapping should eliminate remote fetch"
                     get_thunder_group().FetchRemoteParam(
                         param.spiral_id,
                         non_blocking,
@@ -470,6 +471,7 @@ class SpiralInitContext(InsertPostInitMethodToModuleSubClasses):
                     param.data.copy_(param.spiral_tensor, non_blocking=non_blocking)
                 else:
                     param.data = torch.empty(param.spiral_shape, device=self.local_device, dtype=param.dtype)
+                    assert not get_args().spiral_cross_mapping, "Spiral cross mapping should eliminate remote fetch"
                     get_thunder_group().FetchRemoteParam(
                         param.spiral_id,
                         non_blocking,

--- a/megatron/spiral/schedules.py
+++ b/megatron/spiral/schedules.py
@@ -353,6 +353,11 @@ def forward_backward_pipelining_with_spiral_remap(
 
         recvs, reqs = None, []  # placeholder
         if len(send_ranks) > 0 or len(recv_ranks) > 0:
+            if mpu.is_spiral_cross_mapping():
+                # translate cm_rank back to pp_rank before communication
+                send_ranks = [mpu.translate_cm_rank_to_pp_rank(rank) for rank in send_ranks]
+                recv_ranks = [mpu.translate_cm_rank_to_pp_rank(rank) for rank in recv_ranks]
+
             recvs, reqs = spiral_p2p._communicate(
                 tensor_sends=tensor_sends if len(tensor_sends) > 0 else None,
                 send_ranks=send_ranks if len(send_ranks) > 0 else None,


### PR DESCRIPTION
Cross mapping is a feature that finds optimal mapping to eliminate inter-node parameter fetch.
It currently completely eliminates the inter-node fetch if #fvs=#bvs.
When cross mapping is enabled, pp_ranks are translated into cm_ranks during training.
Remapping is not affected as it is executed based on separate MPI communicator-based ranks.
Important thing is that cm_ranks should be translated into pp_ranks before invoking P2P communication, as it uses pp_rank-based torch.dist group.
For example, `comm_input_ckpt()` in spiral/schedules.py translated the ranks in CkptSendRecvSchedule.  