### PR TITLE
Fix hang when FP16 enabled and fvs!=bvs

### DIFF
--- a/megatron/arguments.py
+++ b/megatron/arguments.py
@@ -436,10 +436,6 @@ def validate_args(args, defaults={}):
         if args.use_distributed_optimizer:
             raise RuntimeError(
                 "SpiralPipe currently does not support distributed optimizer")
-        if args.spiral_cross_mapping:
-            if args.spiral_forward_virtual_size != args.spiral_backward_virtual_size:
-                raise RuntimeError(
-                    "SpiralPipe with cross mapping requires forward and backward virtual size to be the same")
 
     # GQA
     if args.num_key_value_heads is None:

--- a/megatron/core/parallel_state.py
+++ b/megatron/core/parallel_state.py
@@ -1003,7 +1003,7 @@ def destroy_model_parallel():
 
 def apply_spiral_cross_mapping(ranks):
     """ Converts sorted pp rank list into list whose index is cm_rank and element is pp_rank.
-    Maps into pattern which elimiates inter-node fetch (when fvs==bvs) and minimizes intra-node activation comm.
+    Maps into pattern which elimiates inter-node fetch (when fvs==bvs) and minimizes inter-node activation comm.
 
     TODO (SpiralPipe) currently assumes nprocs_per_node=4 and stride=2
     """

--- a/megatron/model/module.py
+++ b/megatron/model/module.py
@@ -196,7 +196,6 @@ class Float16Module(MegatronModule):
 
 
     def set_input_tensor(self, input_tensor):
-        # assert input_tensor.dtype == torch.float16, f"@@@@@@@@@@@@@"
         return self.module.set_input_tensor(input_tensor)
 
 

--- a/megatron/model/module.py
+++ b/megatron/model/module.py
@@ -171,7 +171,12 @@ def float16_to_fp32(val):
 
 class Float16Module(MegatronModule):
 
-    def __init__(self, module, args):
+    def __init__(self, module, args, spiral_disable_cast=False):
+        """Wrap the module with float16/bfloat16 cast.
+
+        Arguments:
+            spiral_disable_cast: bool, whether to disable float32 <-> float16/bfloat16 cast. SpiralPhaseList contains mutliple Float16Modules, while the `fp16/bf16 cast` is only needed at the first Float16Module in the first stage (i.e., fid/bid=0, fbp/bbp=0) and the `fp32 cast` is only needed at the last Float16Module in the last stage (i.e., fid/bid=last, fbp/bbp=last*).
+        """
         super(Float16Module, self).__init__()
 
         if args.fp16:
@@ -186,17 +191,20 @@ class Float16Module(MegatronModule):
             raise Exception('should not be here')
 
         self.float16_convertor = float16_convertor
+        if args.spiral:
+            self.spiral_disable_cast = spiral_disable_cast
 
 
     def set_input_tensor(self, input_tensor):
+        # assert input_tensor.dtype == torch.float16, f"@@@@@@@@@@@@@"
         return self.module.set_input_tensor(input_tensor)
 
 
     def forward(self, *inputs, **kwargs):
-        if mpu.is_pipeline_first_stage():
+        if mpu.is_pipeline_first_stage() and not self.spiral_disable_cast:
             inputs = fp32_to_float16(inputs, self.float16_convertor)
         outputs = self.module(*inputs, **kwargs)
-        if mpu.is_pipeline_last_stage():
+        if mpu.is_pipeline_last_stage() and not self.spiral_disable_cast:
             outputs = float16_to_fp32(outputs)
         return outputs
 

--- a/megatron/spiral/init_context.py
+++ b/megatron/spiral/init_context.py
@@ -457,7 +457,6 @@ class SpiralInitContext(InsertPostInitMethodToModuleSubClasses):
                     ).view(param.spiral_shape)
                 else:
                     param.data = torch.empty(param.spiral_shape, device=self.local_device, dtype=param.dtype)
-                    assert not get_args().spiral_cross_mapping, "Spiral cross mapping should eliminate remote fetch"
                     get_thunder_group().FetchRemoteParam(
                         param.spiral_id,
                         non_blocking,
@@ -471,7 +470,6 @@ class SpiralInitContext(InsertPostInitMethodToModuleSubClasses):
                     param.data.copy_(param.spiral_tensor, non_blocking=non_blocking)
                 else:
                     param.data = torch.empty(param.spiral_shape, device=self.local_device, dtype=param.dtype)
-                    assert not get_args().spiral_cross_mapping, "Spiral cross mapping should eliminate remote fetch"
                     get_thunder_group().FetchRemoteParam(
                         param.spiral_id,
                         non_blocking,

--- a/megatron/training.py
+++ b/megatron/training.py
@@ -382,8 +382,25 @@ def get_model(model_provider_func, model_type=ModelType.encoder_or_decoder, wrap
 
             # wrap model with Float16Module
             if args.fp16 or args.bf16:
+                # only the first or last stage can require cast, where a stage is a spiral phase list
+                # all modules in a spiral phase list shares fid and bid
+                # only the first or last module in the same spiral phase list requires cast
+                enable_cast = (
+                    (fvr == 0 and fbp == 0 and mpu.is_pipeline_first_stage())
+                    or (
+                        fvr == mpu.get_spiral_forward_virtual_size() - 1
+                        and fbp == sbs.get_spiral_forward_stage_build_phase_size() - 1
+                        and mpu.is_pipeline_last_stage()
+                    )
+                    or (bvr == 0 and bbp == 0 and mpu.is_pipeline_first_stage())
+                    or (
+                        bvr == mpu.get_spiral_backward_virtual_size() - 1
+                        and bbp == sbs.get_spiral_backward_stage_build_phase_size() - 1
+                        and mpu.is_pipeline_last_stage()
+                    )
+                )
                 with SpiralWrapperInitContext(enabled=True):
-                    this_model = Float16Module(this_model, args)
+                    this_model = Float16Module(this_model, args, spiral_disable_cast=not enable_cast)
 
             # reset states of the callee
             if mpu.is_spiral_forward_stage():


### PR DESCRIPTION
f≠b이고 fp16일때 발생하는 문제임 (cross mapping이랑 관련 x)

- error: `sbatch -p spipe -N 1 -w v06 ./examples/asplos25/run.sh -j spiral -n opt -s 0 -f 1 -b 2 -t 3 -l 1 -m 1 -g 8`
    
    ```python
    [rank3]: Traceback (most recent call last):
    [rank3]:   File "/home/s6/junyeol/spipe/Megatron-mcrl-2/pretrain_gpt.py", line 116, in <module>
    [rank3]:     pretrain(train_valid_test_datasets_provider,
    [rank3]:   File "/home/s6/junyeol/spipe/Megatron-mcrl-2/megatron/training.py", line 210, in pretrain
    [rank3]:     iteration = train(forward_step_func,
    [rank3]:   File "/home/s6/junyeol/spipe/Megatron-mcrl-2/megatron/training.py", line 1194, in train
    [rank3]:     train_step(forward_step_func,
    [rank3]:   File "/home/s6/junyeol/spipe/Megatron-mcrl-2/megatron/training.py", line 813, in train_step
    [rank3]:     losses_reduced = forward_backward_func(
    [rank3]:   File "/home/s6/junyeol/spipe/Megatron-mcrl-2/megatron/spiral/schedules.py", line 520, in forward_backward_pipelining_with_spiral_remap
    [rank3]:     output_tensor = forward_step(
    [rank3]:   File "/home/s6/junyeol/miniconda3/envs/pytorch-2.3-cuda-12.1-python-3.8-clone/lib/python3.8/site-packages/nvtx/nvtx.py", line 116, in inner
    [rank3]:     result = func(*args, **kwargs)
    [rank3]:   File "/home/s6/junyeol/spipe/Megatron-mcrl-2/megatron/core/pipeline_parallel/schedules.py", line 231, in forward_step
    [rank3]:     output_tensor, loss_func = forward_step_func(data_iterator, model)
    [rank3]:   File "/home/s6/junyeol/spipe/Megatron-mcrl-2/pretrain_gpt.py", line 85, in forward_step
    [rank3]:     output_tensor = model(tokens, position_ids, attention_mask,
    [rank3]:   File "/home/s6/junyeol/miniconda3/envs/pytorch-2.3-cuda-12.1-python-3.8-clone/lib/python3.8/site-packages/torch/nn/modules/module.py", line 1532, in _wrapped_call_impl
    [rank3]:     return self._call_impl(*args, **kwargs)
    [rank3]:   File "/home/s6/junyeol/miniconda3/envs/pytorch-2.3-cuda-12.1-python-3.8-clone/lib/python3.8/site-packages/torch/nn/modules/module.py", line 1541, in _call_impl
    [rank3]:     return forward_call(*args, **kwargs)
    [rank3]:   File "/home/s6/junyeol/spipe/Megatron-mcrl-2/megatron/model/distributed.py", line 58, in forward
    [rank3]:     return self.module(*inputs, **kwargs)
    [rank3]:   File "/home/s6/junyeol/miniconda3/envs/pytorch-2.3-cuda-12.1-python-3.8-clone/lib/python3.8/site-packages/torch/nn/modules/module.py", line 1532, in _wrapped_call_impl
    [rank3]:     return self._call_impl(*args, **kwargs)
    [rank3]:   File "/home/s6/junyeol/miniconda3/envs/pytorch-2.3-cuda-12.1-python-3.8-clone/lib/python3.8/site-packages/torch/nn/modules/module.py", line 1541, in _call_impl
    [rank3]:     return forward_call(*args, **kwargs)
    [rank3]:   File "/home/s6/junyeol/spipe/Megatron-mcrl-2/megatron/spiral/module.py", line 54, in forward
    [rank3]:     output_tensor = module(*args, **kwargs)
    [rank3]:   File "/home/s6/junyeol/miniconda3/envs/pytorch-2.3-cuda-12.1-python-3.8-clone/lib/python3.8/site-packages/torch/nn/modules/module.py", line 1532, in _wrapped_call_impl
    [rank3]:     return self._call_impl(*args, **kwargs)
    [rank3]:   File "/home/s6/junyeol/miniconda3/envs/pytorch-2.3-cuda-12.1-python-3.8-clone/lib/python3.8/site-packages/torch/nn/modules/module.py", line 1541, in _call_impl
    [rank3]:     return forward_call(*args, **kwargs)
    [rank3]:   File "/home/s6/junyeol/spipe/Megatron-mcrl-2/megatron/model/module.py", line 198, in forward
    [rank3]:     outputs = self.module(*inputs, **kwargs)
    [rank3]:   File "/home/s6/junyeol/miniconda3/envs/pytorch-2.3-cuda-12.1-python-3.8-clone/lib/python3.8/site-packages/torch/nn/modules/module.py", line 1532, in _wrapped_call_impl
    [rank3]:     return self._call_impl(*args, **kwargs)
    [rank3]:   File "/home/s6/junyeol/miniconda3/envs/pytorch-2.3-cuda-12.1-python-3.8-clone/lib/python3.8/site-packages/torch/nn/modules/module.py", line 1541, in _call_impl
    [rank3]:     return forward_call(*args, **kwargs)
    [rank3]:   File "/home/s6/junyeol/spipe/Megatron-mcrl-2/megatron/model/gpt_model.py", line 87, in forward
    [rank3]:     lm_output = self.language_model(
    [rank3]:   File "/home/s6/junyeol/miniconda3/envs/pytorch-2.3-cuda-12.1-python-3.8-clone/lib/python3.8/site-packages/torch/nn/modules/module.py", line 1532, in _wrapped_call_impl
    [rank3]:     return self._call_impl(*args, **kwargs)
    [rank3]:   File "/home/s6/junyeol/miniconda3/envs/pytorch-2.3-cuda-12.1-python-3.8-clone/lib/python3.8/site-packages/torch/nn/modules/module.py", line 1541, in _call_impl
    [rank3]:     return forward_call(*args, **kwargs)
    [rank3]:   File "/home/s6/junyeol/spipe/Megatron-mcrl-2/megatron/model/language_model.py", line 511, in forward
    [rank3]:     encoder_output = self.encoder(
    [rank3]:   File "/home/s6/junyeol/miniconda3/envs/pytorch-2.3-cuda-12.1-python-3.8-clone/lib/python3.8/site-packages/torch/nn/modules/module.py", line 1532, in _wrapped_call_impl
    [rank3]:     return self._call_impl(*args, **kwargs)
    [rank3]:   File "/home/s6/junyeol/miniconda3/envs/pytorch-2.3-cuda-12.1-python-3.8-clone/lib/python3.8/site-packages/torch/nn/modules/module.py", line 1541, in _call_impl
    [rank3]:     return forward_call(*args, **kwargs)
    [rank3]:   File "/home/s6/junyeol/spipe/Megatron-mcrl-2/megatron/model/transformer.py", line 1734, in forward
    [rank3]:     hidden_states = layer(
    [rank3]:   File "/home/s6/junyeol/miniconda3/envs/pytorch-2.3-cuda-12.1-python-3.8-clone/lib/python3.8/site-packages/torch/nn/modules/module.py", line 1532, in _wrapped_call_impl
    [rank3]:     return self._call_impl(*args, **kwargs)
    [rank3]:   File "/home/s6/junyeol/miniconda3/envs/pytorch-2.3-cuda-12.1-python-3.8-clone/lib/python3.8/site-packages/torch/nn/modules/module.py", line 1541, in _call_impl
    [rank3]:     return forward_call(*args, **kwargs)
    [rank3]:   File "/home/s6/junyeol/spipe/Megatron-mcrl-2/megatron/model/transformer.py", line 1081, in forward
    [rank3]:     layernorm_output = self.input_layernorm(hidden_states)
    [rank3]:   File "/home/s6/junyeol/miniconda3/envs/pytorch-2.3-cuda-12.1-python-3.8-clone/lib/python3.8/site-packages/torch/nn/modules/module.py", line 1532, in _wrapped_call_impl
    [rank3]:     return self._call_impl(*args, **kwargs)
    [rank3]:   File "/home/s6/junyeol/miniconda3/envs/pytorch-2.3-cuda-12.1-python-3.8-clone/lib/python3.8/site-packages/torch/nn/modules/module.py", line 1541, in _call_impl
    [rank3]:     return forward_call(*args, **kwargs)
    [rank3]:   File "/home/s6/junyeol/spipe/Megatron-mcrl-2/megatron/model/fused_layer_norm.py", line 80, in forward
    [rank3]:     return FusedLayerNormAffineFunction.apply(input, weight, self.bias, self.normalized_shape, self.eps)
    [rank3]:   File "/home/s6/junyeol/miniconda3/envs/pytorch-2.3-cuda-12.1-python-3.8-clone/lib/python3.8/site-packages/torch/autograd/function.py", line 598, in apply
    [rank3]:     return super().apply(*args, **kwargs)  # type: ignore[misc]
    [rank3]:   File "/home/s6/junyeol/miniconda3/envs/pytorch-2.3-cuda-12.1-python-3.8-clone/lib/python3.8/site-packages/apex/normalization/fused_layer_norm.py", line 43, in forward
    [rank3]:     output, mean, invvar = fused_layer_norm_cuda.forward_affine(
    [rank3]: RuntimeError: expected scalar type Float but found Half
    ```
    
- input tensor ckpt를 send 하거나, 스스로 recv 할 때 type 다른게 있는거 같음
    - f1 b1:
    
    !!!!!!!!!input.dtype=torch.float16 weight.dtype=torch.float16 self.bias.dtype=torch.float16 self.normalized_shape=torch.Size([1024]) self.eps=1e-05
    
    - f1 b2:
    
    !!!!!!!!!input.dtype=torch.float32 weight.dtype=torch.float16 self.bias.dtype=torch.float16 self.normalized_shape=torch.Size([1024]) self.eps=1e-05
    
- MixedFusedLayerNorm으로 들어가는 input이 fp32인게 있음.
    - ParallelTransformerLayer 맨 앞에 붙어있다.
- 원인: SpiralPhaseList [Float16Module(GPTModel), Float16Module, …] 로 들어있는데, Float16Module의 기존 정의 상 pipeline first/last stage면 casting을 한다. SpiralPhastList 내의 모듈들은 같은 fid, bid를 갖기 때문에 casting이 불필요하게 여러번 되고 있었고 에러로 이어졌음.
    
    ```python
    # 기존 구현
    class Float16Module(MegatronModule):
    
        def forward(self, *inputs, **kwargs):
            if mpu.is_pipeline_first_stage():
                inputs = fp32_to_float16(inputs, self.float16_convertor)
            outputs = self.module(*inputs, **kwargs)
            if mpu.is_pipeline_last_stage():
                outputs = float16_to_fp32(outputs)
            return outputs
    ```
    
- 해결: Float16Module에 disable_cast 옵션을 더했다.