### PR TITLE
Fix free gradients indentation error in Mobius code

### DIFF
--- a/megatron/spiral/schedules.py
+++ b/megatron/spiral/schedules.py
@@ -1500,23 +1500,23 @@ def forward_backward_pipelining_with_spiral(
                         (update_successful, grad_norm, num_zeros_in_grad)
                     )
 
-        with torch.cuda.stream(get_thunder_cuda_manager().Stream("free")):
-            if (
-                get_thunder_cuda_manager().wait_event(offload_event_queries.pop(f"offload_grad:b{bwd_stage_id}"))
-                == -1
-            ):
-                raise RuntimeError("wait_event failed")
+            with torch.cuda.stream(get_thunder_cuda_manager().Stream("free")):
+                if (
+                    get_thunder_cuda_manager().wait_event(offload_event_queries.pop(f"offload_grad:b{bwd_stage_id}"))
+                    == -1
+                ):
+                    raise RuntimeError("wait_event failed")
 
-            # free bwd stage grads
-            model[bwd_stage_id].spiral_free_grad()
-            free_grad_curr = get_thunder_cuda_manager().Event(
-                "free",
-                None,
-                tag=f"free_grad:b{bwd_stage_id}",
-            )
-            if get_thunder_cuda_manager().record_event(free_grad_curr) == -1:
-                raise RuntimeError("record_event failed")
-            free_event_queries[free_grad_curr.tag] = free_grad_curr
+                # free bwd stage grads
+                model[bwd_stage_id].spiral_free_grad()
+                free_grad_curr = get_thunder_cuda_manager().Event(
+                    "free",
+                    None,
+                    tag=f"free_grad:b{bwd_stage_id}",
+                )
+                if get_thunder_cuda_manager().record_event(free_grad_curr) == -1:
+                    raise RuntimeError("record_event failed")
+                free_event_queries[free_grad_curr.tag] = free_grad_curr
 
         mpu.set_spiral_backward_virtual_rank(None)
     # end bwd

--- a/megatron/spiral/schedules.py
+++ b/megatron/spiral/schedules.py
@@ -818,6 +818,7 @@ def forward_backward_pipelining_with_spiral_remap(
             if get_thunder_cuda_manager().record_event(free_curr) == -1:
                 raise RuntimeError("record_event failed")
             free_event_queries[free_curr.tag] = free_curr
+        # end free bwd stage
 
         # if grad offload is not overlapped, then it should be reduced and offloaded after `forward_backward_func` at train_step()
         if offload_grad_after_bwd_stage:
@@ -872,6 +873,7 @@ def forward_backward_pipelining_with_spiral_remap(
                 if get_thunder_cuda_manager().record_event(free_grad_curr) == -1:
                     raise RuntimeError("record_event failed")
                 free_event_queries[free_grad_curr.tag] = free_grad_curr
+        # end offload & free grad
 
         mpu.set_spiral_backward_virtual_rank(None)
     # end bwd
@@ -1463,6 +1465,7 @@ def forward_backward_pipelining_with_spiral(
             if get_thunder_cuda_manager().record_event(free_curr) == -1:
                 raise RuntimeError("record_event failed")
             free_event_queries[free_curr.tag] = free_curr
+        # end free bwd stage
 
         # if grad offload is not overlapped, then it should be reduced and offloaded after `forward_backward_func` at train_step()
         if offload_grad_after_bwd_stage:
@@ -1517,6 +1520,7 @@ def forward_backward_pipelining_with_spiral(
                 if get_thunder_cuda_manager().record_event(free_grad_curr) == -1:
                     raise RuntimeError("record_event failed")
                 free_event_queries[free_grad_curr.tag] = free_grad_curr
+        # end offload & free grad
 
         mpu.set_spiral_backward_virtual_rank(None)
     # end bwd


### PR DESCRIPTION
Freeing gradients during schedule should only be triggered when offloading gradients after backward stage.
Previous code errors when launching mobius without `--spiral-overlap-offload-grad`.
This PR fixes this issue.