### PR TITLE
Set thread cpu affinity to not use the main thread cpu

### DIFF
--- a/csrc/common/util.hpp
+++ b/csrc/common/util.hpp
@@ -1,6 +1,9 @@
 #pragma once
 
 #include <cassert>
+#include <vector>
+#include <algorithm>
+#include <sched.h>
 
 #define CHECK_CUDA(call)                                                       \
   do {                                                                         \
@@ -55,3 +58,32 @@
       assert(false);                                                           \
     }                                                                          \
   } while (0)
+
+void set_affinity(const std::vector<int>& excluded_cpus = {}) {
+  cpu_set_t cpu_set;
+  CPU_ZERO(&cpu_set);
+
+  for (int i = 0; i < CPU_SETSIZE; ++i) {
+    if (std::find(excluded_cpus.begin(), excluded_cpus.end(), i) == excluded_cpus.end()) {
+      CPU_SET(i, &cpu_set);
+    }
+  }
+
+  assert(sched_setaffinity(0, sizeof(cpu_set_t), &cpu_set) == 0);
+}
+
+std::vector<int> get_affinity() {
+  std::vector<int> cpu_affinity;
+
+  cpu_set_t cpu_set;
+  CPU_ZERO(&cpu_set);
+  assert(sched_getaffinity(0, sizeof(cpu_set_t), &cpu_set) == 0);
+
+  for (int i = 0; i < CPU_SETSIZE; ++i) {
+    if (CPU_ISSET(i, &cpu_set)) {
+      cpu_affinity.push_back(i);
+    }
+  }
+
+  return cpu_affinity;
+}

--- a/csrc/spiral_cpu_adam/cpu_adam.cpp
+++ b/csrc/spiral_cpu_adam/cpu_adam.cpp
@@ -39,15 +39,17 @@ struct ThreadSafeOptimizer {
   std::mutex m;
   std::vector<std::shared_ptr<torch::Tensor>> fp32_param_list;
   std::vector<float> found_inf_list;
+  std::vector<int> excluded_cpus;
 
   ThreadSafeOptimizer(
       std::unordered_map<int, std::shared_ptr<void>> group_s_opts,
       const int nparams,
       const int pool_size,
       const bool half_precision,
-      const bool should_log)
+      const bool should_log,
+      const std::vector<int>& excluded_cpus)
     : group_s_opts(group_s_opts), pool(pool_size), nparams(nparams),
-      nparams_submitted(0), should_log(should_log)
+      nparams_submitted(0), should_log(should_log), excluded_cpus(excluded_cpus)
   {
     if (half_precision)
       fp32_param_list.resize(nparams);
@@ -87,8 +89,9 @@ int spiral_create_adam_optimizer(int optimizer_id,
   else if (pool_size < 0)
     throw std::runtime_error("Invalid thread pool size");
 
+  std::vector<int> excluded_cpus = get_affinity();
   s_optimizers[optimizer_id] = std::make_shared<ThreadSafeOptimizer>(
-      group_s_opts, nparams, pool_size, half_precision, should_log);
+      group_s_opts, nparams, pool_size, half_precision, should_log, excluded_cpus);
 
   if (should_log) {
     printf("[%ld] ThreadSafeOptimizer #%d is created with %d threads for %d "
@@ -153,6 +156,9 @@ int _spiral_adam_step(int optimizer_id,
 {
   auto ts_opt =
       std::static_pointer_cast<ThreadSafeOptimizer>(s_optimizers[optimizer_id]);
+  
+  // Set thread cpu affinity to not use the main thread cpu
+  set_affinity(ts_opt->excluded_cpus);
 
   if (ev_long == 0) {
     throw std::runtime_error("Event is not recorded");

--- a/csrc/spiral_cpu_adam/cpu_adam.cpp
+++ b/csrc/spiral_cpu_adam/cpu_adam.cpp
@@ -70,7 +70,8 @@ int spiral_create_adam_optimizer(int optimizer_id,
                                  float eps,
                                  float weight_decay,
                                  bool adamw_mode,
-                                 bool should_log)
+                                 bool should_log,
+                                 std::vector<int> excluded_cpus)
 {
   /*
    * Each backward stage has a ThreadSafeOptimizer and a ThreadPool.
@@ -89,7 +90,10 @@ int spiral_create_adam_optimizer(int optimizer_id,
   else if (pool_size < 0)
     throw std::runtime_error("Invalid thread pool size");
 
-  std::vector<int> excluded_cpus = get_affinity();
+  if (excluded_cpus.empty()) {
+    // If excludede_cpus is not set, assign the CPU affinity of the main thread
+    excluded_cpus = get_affinity();
+  }
   s_optimizers[optimizer_id] = std::make_shared<ThreadSafeOptimizer>(
       group_s_opts, nparams, pool_size, half_precision, should_log, excluded_cpus);
 

--- a/megatron/spiral/__init__.py
+++ b/megatron/spiral/__init__.py
@@ -2,6 +2,7 @@ from .initialize import (
     SpiralBackend,
     get_thunder_group,
     get_thunder_cuda_manager,
+    get_node_cpu_affinity,
 )
 from .init_context import SpiralInitContext, SpiralParamStatus
 from .wrapper_init_context import SpiralWrapperInitContext

--- a/megatron/spiral/initialize.py
+++ b/megatron/spiral/initialize.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass
 import atexit
 
 import torch
+import torch.distributed as dist
 
 import spiral_helper
 
@@ -31,6 +32,7 @@ class SpiralBackend:
             alignment,
         )
         self.thunder_cuda_manager = SpiralCUDAManager()
+        self.node_cpu_affinity = init_node_cpu_affinity()
         global SPIRAL_BACKEND
         SPIRAL_BACKEND = self
 
@@ -53,6 +55,31 @@ def get_thunder_cuda_manager():
     global SPIRAL_BACKEND
     assert SPIRAL_BACKEND is not None, "SpiralBackend is not initialized"
     return SPIRAL_BACKEND.thunder_cuda_manager
+
+
+def get_node_cpu_affinity():
+    global SPIRAL_BACKEND
+    assert SPIRAL_BACKEND is not None, "SpiralBackend is not initialized"
+    return SPIRAL_BACKEND.node_cpu_affinity
+
+
+def init_node_cpu_affinity():
+    """Share CPU affinity only with ranks on the same node."""
+    import os, socket
+    hostname = socket.gethostname()
+    world_size = dist.get_world_size()
+    gathered_hostnames = [None] * world_size
+    dist.all_gather_object(gathered_hostnames, hostname)
+    same_node_ranks = [i for i, h in enumerate(gathered_hostnames) if h == hostname]
+
+    node_group = dist.new_group(same_node_ranks)
+
+    affinity = os.sched_getaffinity(0)
+    node_affinity = torch.tensor([1 if i in affinity else 0 for i in range(os.cpu_count())], dtype=torch.int32, device='cuda')
+
+    dist.all_reduce(node_affinity, op=dist.ReduceOp.SUM, group=node_group)
+
+    return [i for i, value in enumerate(node_affinity) if value != 0]
 
 
 @dataclass(frozen=True)

--- a/megatron/spiral/optimizer/cpu_adam.py
+++ b/megatron/spiral/optimizer/cpu_adam.py
@@ -4,6 +4,7 @@ from megatron import get_args
 
 from deepspeed.utils import logger
 from deepspeed.utils.logging import should_log_le
+from megatron.spiral import get_node_cpu_affinity
 
 from .cpu_adam_builder import SpiralCPUAdamBuilder
 
@@ -115,6 +116,7 @@ class SpiralCPUAdam(torch.optim.Optimizer):
             weight_decay,
             adamw_mode,
             should_log_le("info"),
+            get_node_cpu_affinity()
         )
         self.inv_scale = 0
         self.ev_long = -1


### PR DESCRIPTION
### Issue
- Even when mixed precision logic is ported to cpp, performance degradation is occur for fwd, bwd operations
- The CPU used by the optimizer thread was found to be overlapping with the pytorch main thread
- Solved by setting thread cpu affinity to not use the main thread cpu

### Note
- Needs to check if it can be solved by other than CPU affinity settings