### PR TITLE
Implement bypassing optimizer

### DIFF
--- a/csrc/spiral_cpu_adam/cpu_adam.cpp
+++ b/csrc/spiral_cpu_adam/cpu_adam.cpp
@@ -286,6 +286,104 @@ int spiral_adam_step(int optimizer_id,
   return 0;
 }
 
+int spiral_adam_rollback(int optimizer_id,
+                         int group_id,
+                         int param_id,
+                         size_t step,
+                         float lr,
+                         float beta1,
+                         float beta2,
+                         float epsilon,
+                         float weight_decay,
+                         bool bias_correction,
+                         torch::Tensor& params,
+                         torch::Tensor& grads,
+                         torch::Tensor& exp_avg,
+                         torch::Tensor& exp_avg_sq,
+                         float inv_scale,
+                         bool half_precision,
+                         long ev_long)
+{
+  auto ts_opt =
+      std::static_pointer_cast<ThreadSafeOptimizer>(s_optimizers[optimizer_id]);
+
+  if (ev_long == 0) {
+    throw std::runtime_error("Event is not recorded");
+  } else if (ev_long == -1) {
+    if (ts_opt->should_log)
+      printf("(pid:%ld,tid:%ld) Skip null event\n", (long)getpid(),
+             (long)gettid());
+  } else {
+    if (ts_opt->should_log)
+      printf("(pid:%ld,tid:%ld) Wait event:%ld\n", (long)getpid(),
+             (long)gettid(), ev_long);
+
+    cudaEvent_t ev = (cudaEvent_t)ev_long;
+    CHECK_CUDA(cudaEventSynchronize(ev));
+  }
+
+  std::string range_name = "Rollback " + std::to_string(param_id);
+  nvtxRangePushA(range_name.c_str());
+
+  torch::Tensor fp32_params;
+  torch::Tensor fp32_grads;
+  if (half_precision) {
+    assert(param_id < ts_opt->fp32_param_list.size());
+    if(!ts_opt->fp32_param_list[param_id]) {
+      ts_opt->fp32_param_list[param_id] = std::make_shared<torch::Tensor>(params.to(torch::kFloat));
+    }
+    fp32_params = *ts_opt->fp32_param_list[param_id];
+    fp32_grads = grads.to(torch::kFloat);
+  } else {
+    fp32_params = params;
+    fp32_grads = grads;
+  }
+
+  auto params_c = fp32_params.contiguous();
+  auto grads_c = fp32_grads.contiguous();
+  auto exp_avg_c = exp_avg.contiguous();
+  auto exp_avg_sq_c = exp_avg_sq.contiguous();
+
+  // assert(params.options().dtype() == grads.options().dtype());
+
+  float* params_ptr = (float*)params_c.data_ptr();
+  float* grads_ptr = (float*)grads_c.data_ptr();
+  float* exp_avg_ptr = (float*)exp_avg_c.data_ptr();
+  float* exp_avg_sq_ptr = (float*)exp_avg_sq_c.data_ptr();
+
+  // unscale-and-check-inf
+  if (half_precision) {
+    torch::Tensor found_inf = torch::tensor({0.0f}, torch::dtype(torch::kFloat32));
+    torch::Tensor inv_scale_tensor = torch::tensor({inv_scale}, torch::dtype(torch::kFloat32));
+
+    std::vector<at::Tensor> scaled_grads;
+    scaled_grads.push_back(fp32_grads);
+
+    at::_amp_foreach_non_finite_check_and_unscale_(scaled_grads, found_inf, inv_scale_tensor);
+
+    if (found_inf.item<float>() > 0) {
+      nvtxRangePop();
+      return 0;
+    }
+  }
+
+  auto group_s_opt = std::static_pointer_cast<SpiralAdamOptimizer>(
+      ts_opt->group_s_opts[group_id]);
+
+  // Modifying the states of group_s_opt is safe, since param_group shares the
+  // same state value refer to megatron/spiral/cpu_adam.py step()
+  group_s_opt->IncrementStep(step, beta1, beta2);
+  group_s_opt->update_state(lr, epsilon, weight_decay, bias_correction);
+  group_s_opt->Rollback(params_ptr, grads_ptr, exp_avg_ptr, exp_avg_sq_ptr, params_c.numel());
+
+  if (half_precision) {
+    params.copy_(fp32_params.to(params.options().dtype()));
+  }
+
+  nvtxRangePop();
+  return 0;
+}
+
 void spiral_adam_synchronize(int optimizer_id, torch::Tensor& found_inf)
 {
   auto ts_opt =
@@ -336,6 +434,7 @@ void spiral_adam_synchronize(int optimizer_id, torch::Tensor& found_inf)
 PYBIND11_MODULE(TORCH_EXTENSION_NAME, m)
 {
   m.def("adam_update", &spiral_adam_step, "SpiralPipe CPU Adam update (C++) ");
+  m.def("adam_rollback", &spiral_adam_rollback, "SpiralPipe CPU Adam rollback (C++) ");
   m.def("create_adam", &spiral_create_adam_optimizer, "SpiralPipe CPU Adam (C++)");
   m.def("destroy_adam", &spiral_destroy_adam_optimizer, "SpiralPipe CPU Adam destroy (C++)");
   m.def("adam_sync", &spiral_adam_synchronize, "SpiralPipe CPU Adam join threads (C++)");

--- a/csrc/spiral_cpu_adam/cpu_adam.cpp
+++ b/csrc/spiral_cpu_adam/cpu_adam.cpp
@@ -374,7 +374,7 @@ int spiral_adam_rollback(int optimizer_id,
   // same state value refer to megatron/spiral/cpu_adam.py step()
   group_s_opt->IncrementStep(step, beta1, beta2);
   group_s_opt->update_state(lr, epsilon, weight_decay, bias_correction);
-  group_s_opt->Rollback(params_ptr, grads_ptr, exp_avg_ptr, exp_avg_sq_ptr, params_c.numel());
+  group_s_opt->Rollback_8(params_ptr, grads_ptr, exp_avg_ptr, exp_avg_sq_ptr, params_c.numel());
 
   if (half_precision) {
     params.copy_(fp32_params.to(params.options().dtype()));

--- a/csrc/spiral_cpu_adam/cpu_adam.cpp
+++ b/csrc/spiral_cpu_adam/cpu_adam.cpp
@@ -284,23 +284,23 @@ int spiral_adam_step(int optimizer_id,
   return 0;
 }
 
-int spiral_adam_rollback(int optimizer_id,
-                         int group_id,
-                         int param_id,
-                         size_t step,
-                         float lr,
-                         float beta1,
-                         float beta2,
-                         float epsilon,
-                         float weight_decay,
-                         bool bias_correction,
-                         torch::Tensor& params,
-                         torch::Tensor& grads,
-                         torch::Tensor& exp_avg,
-                         torch::Tensor& exp_avg_sq,
-                         float inv_scale,
-                         bool half_precision,
-                         long ev_long)
+int _spiral_adam_rollback(int optimizer_id,
+                          int group_id,
+                          int param_id,
+                          size_t step,
+                          float lr,
+                          float beta1,
+                          float beta2,
+                          float epsilon,
+                          float weight_decay,
+                          bool bias_correction,
+                          torch::Tensor& params,
+                          torch::Tensor& grads,
+                          torch::Tensor& exp_avg,
+                          torch::Tensor& exp_avg_sq,
+                          float inv_scale,
+                          bool half_precision,
+                          long ev_long)
 {
   auto ts_opt =
       std::static_pointer_cast<ThreadSafeOptimizer>(s_optimizers[optimizer_id]);
@@ -379,6 +379,45 @@ int spiral_adam_rollback(int optimizer_id,
   }
 
   nvtxRangePop();
+  return 0;
+}
+
+int spiral_adam_rollback(int optimizer_id,
+                         int group_id,
+                         int param_id,
+                         size_t step,
+                         float lr,
+                         float beta1,
+                         float beta2,
+                         float epsilon,
+                         float weight_decay,
+                         bool bias_correction,
+                         torch::Tensor& params,
+                         torch::Tensor& grads,
+                         torch::Tensor& exp_avg,
+                         torch::Tensor& exp_avg_sq,
+                         float inv_scale,
+                         bool half_precision,
+                         long ev_long)
+{
+  auto ts_opt =
+      std::static_pointer_cast<ThreadSafeOptimizer>(s_optimizers[optimizer_id]);
+
+  std::lock_guard<std::mutex> lck(ts_opt->m);
+
+  if (ts_opt->should_log) {
+    printf("(pid:%ld) ThreadSafeOptimizer #%d param #%d rollback called with "
+           "param.ptr=%p, grad.ptr=%p\n",
+           (long)getpid(), optimizer_id, ts_opt->nparams_submitted,
+           params.data_ptr(), grads.data_ptr());
+  }
+
+  ts_opt->futures.emplace_back(
+      ts_opt->pool.submit(_spiral_adam_rollback, optimizer_id, group_id, param_id, step, lr,
+                          beta1, beta2, epsilon, weight_decay, bias_correction,
+                          params, grads, exp_avg, exp_avg_sq, inv_scale, half_precision, ev_long));
+  ts_opt->nparams_submitted++;
+
   return 0;
 }
 

--- a/csrc/spiral_cpu_adam/cpu_adam.cpp
+++ b/csrc/spiral_cpu_adam/cpu_adam.cpp
@@ -161,7 +161,7 @@ int _spiral_adam_step(int optimizer_id,
     CHECK_CUDA(cudaEventSynchronize(ev));
   }
 
-  std::string range_name = "Thread " + std::to_string(param_id);
+  std::string range_name = "Step " + std::to_string(param_id);
   nvtxRangePushA(range_name.c_str());
 
   torch::Tensor fp32_params;
@@ -225,9 +225,7 @@ int _spiral_adam_step(int optimizer_id,
   // same state value refer to megatron/spiral/cpu_adam.py step()
   group_s_opt->IncrementStep(step, beta1, beta2);
   group_s_opt->update_state(lr, epsilon, weight_decay, bias_correction);
-
-  group_s_opt->Step_8(params_ptr, grads_ptr, exp_avg_ptr, exp_avg_sq_ptr,
-                      params_c.numel(), nullptr, false);
+  group_s_opt->Step_8(params_ptr, grads_ptr, exp_avg_ptr, exp_avg_sq_ptr, params_c.numel());
 
   if (half_precision) {
     params.copy_(fp32_params.to(params.options().dtype()));

--- a/csrc/spiral_cpu_adam/cpu_adam.cpp
+++ b/csrc/spiral_cpu_adam/cpu_adam.cpp
@@ -8,14 +8,6 @@
 #include <type_traits>
 #include <unordered_map>
 
-#if defined(__ENABLE_CUDA__)
-#include "cublas_v2.h"
-#include "cuda.h"
-#include "curand.h"
-#include "custom_cuda_layers.h"
-#include <cuda_runtime_api.h>
-#endif
-
 #include "thread_pool.hpp"
 #include "util.hpp"
 #include <cuda_runtime.h>
@@ -251,101 +243,7 @@ int _spiral_adam_step(int optimizer_id,
            exp_avg_sq_c.numel());
   }
 
-#if defined(__ENABLE_CUDA__) or defined(__ENABLE_CANN__)
-  group_s_opt->SynchronizeStreams();
-#endif
   nvtxRangePop();
-  return 0;
-}
-
-int _spiral_adam_step_plus_copy(int optimizer_id,
-                                int group_id,
-                                size_t step,
-                                float lr,
-                                float beta1,
-                                float beta2,
-                                float epsilon,
-                                float weight_decay,
-                                bool bias_correction,
-                                torch::Tensor& params,
-                                torch::Tensor& grads,
-                                torch::Tensor& exp_avg,
-                                torch::Tensor& exp_avg_sq,
-                                torch::Tensor& device_params,
-                                long ev_long)
-{
-#if defined(__ENABLE_CUDA__) or defined(__ENABLE_CANN__)
-  auto ts_opt =
-      std::static_pointer_cast<ThreadSafeOptimizer>(s_optimizers[optimizer_id]);
-
-  if (ev_long == 0) {
-    throw std::runtime_error("Event is not recorded");
-  } else if (ev_long == -1) {
-    if (ts_opt->should_log)
-      printf("(pid:%ld,tid:%ld) Skip null event\n", (long)getpid(),
-             (long)gettid());
-  } else {
-    if (ts_opt->should_log)
-      printf("(pid:%ld,tid:%ld) Wait event:%ld\n", (long)getpid(),
-             (long)gettid(), ev_long);
-
-    cudaEvent_t ev = (cudaEvent_t)ev_long;
-    CHECK_CUDA(cudaEventSynchronize(ev));
-  }
-
-  auto params_c = params.contiguous();
-  auto device_params_c = device_params.contiguous();
-  auto exp_avg_c = exp_avg.contiguous();
-  auto exp_avg_sq_c = exp_avg_sq.contiguous();
-  auto grads_c = grads.contiguous();
-
-  float* params_ptr = (float*)params_c.data_ptr();
-  float* grads_ptr = (float*)grads_c.data_ptr();
-  ds_half_precision_t* device_params_ptr =
-      (ds_half_precision_t*)device_params_c.data_ptr();
-  float* exp_avg_ptr = (float*)exp_avg_c.data_ptr();
-  float* exp_avg_sq_ptr = (float*)exp_avg_sq_c.data_ptr();
-
-  if (_DEBUG_OPTIMIZER) {
-    printf("Updating param=(%p,%f,%zu) device_parm=(%p,%f,%zu) with "
-           "grad=(%p,%f,%zu), "
-           "momentum=(%p,%f,%zu), variance=(%p,%f,%zu)\n",
-           params_ptr, at::mean(params).item().toFloat(), params_c.numel(),
-           device_params_ptr, at::mean(device_params).item().toFloat(),
-           device_params_c.numel(), grads_ptr, at::mean(grads).item().toFloat(),
-           grads_c.numel(), exp_avg_ptr, at::mean(exp_avg).item().toFloat(),
-           exp_avg_c.numel(), exp_avg_sq_ptr,
-           at::mean(exp_avg_sq).item().toFloat(), exp_avg_sq_c.numel());
-  }
-
-  auto group_s_opt = std::static_pointer_cast<SpiralAdamOptimizer>(
-      ts_opt->group_s_opts[group_id]);
-
-  // Modifying the states of group_s_opt is safe, since param_group shares the
-  // same state value refer to megatron/spiral/cpu_adam.py step()
-  group_s_opt->IncrementStep(step, beta1, beta2);
-  group_s_opt->update_state(lr, epsilon, weight_decay, bias_correction);
-
-  group_s_opt->Step_8(params_ptr, grads_ptr, exp_avg_ptr, exp_avg_sq_ptr,
-                      params_c.numel(), device_params_ptr,
-                      (params.options().dtype() == at::kHalf));
-
-  if (_DEBUG_OPTIMIZER) {
-    printf("Updated param=(%p,%f,%zu) device_parm=(%p,%f,%zu) with "
-           "grad=(%p,%f,%zu), "
-           "momentum=(%p,%f,%zu), variance=(%p,%f,%zu)\n",
-           params_ptr, at::mean(params).item().toFloat(), params_c.numel(),
-           device_params_ptr, at::mean(device_params).item().toFloat(),
-           device_params_c.numel(), grads_ptr, at::mean(grads).item().toFloat(),
-           grads_c.numel(), exp_avg_ptr, at::mean(exp_avg).item().toFloat(),
-           exp_avg_c.numel(), exp_avg_sq_ptr,
-           at::mean(exp_avg_sq).item().toFloat(), exp_avg_sq_c.numel());
-  }
-
-  group_s_opt->SynchronizeStreams();
-#else
-  assert(false);
-#endif
   return 0;
 }
 
@@ -383,43 +281,6 @@ int spiral_adam_step(int optimizer_id,
       ts_opt->pool.submit(_spiral_adam_step, optimizer_id, group_id, param_id, step, lr,
                           beta1, beta2, epsilon, weight_decay, bias_correction,
                           params, grads, exp_avg, exp_avg_sq, inv_scale, half_precision, ev_long));
-  ts_opt->nparams_submitted++;
-
-  return 0;
-}
-
-int spiral_adam_step_plus_copy(int optimizer_id,
-                               int group_id,
-                               size_t step,
-                               float lr,
-                               float beta1,
-                               float beta2,
-                               float epsilon,
-                               float weight_decay,
-                               bool bias_correction,
-                               torch::Tensor& params,
-                               torch::Tensor& grads,
-                               torch::Tensor& exp_avg,
-                               torch::Tensor& exp_avg_sq,
-                               torch::Tensor& device_params,
-                               long ev_long)
-{
-  auto ts_opt =
-      std::static_pointer_cast<ThreadSafeOptimizer>(s_optimizers[optimizer_id]);
-
-  std::lock_guard<std::mutex> lck(ts_opt->m);
-
-  if (ts_opt->should_log) {
-    printf("(pid:%ld) ThreadSafeOptimizer #%d param #%d step called with "
-           "param.ptr=%p, grad.ptr=%p\n",
-           (long)getpid(), optimizer_id, ts_opt->nparams_submitted,
-           params.data_ptr(), grads.data_ptr());
-  }
-
-  ts_opt->futures.emplace_back(ts_opt->pool.submit(
-      _spiral_adam_step_plus_copy, optimizer_id, group_id, step, lr, beta1,
-      beta2, epsilon, weight_decay, bias_correction, params, grads, exp_avg,
-      exp_avg_sq, device_params, ev_long));
   ts_opt->nparams_submitted++;
 
   return 0;
@@ -475,12 +336,7 @@ void spiral_adam_synchronize(int optimizer_id, torch::Tensor& found_inf)
 PYBIND11_MODULE(TORCH_EXTENSION_NAME, m)
 {
   m.def("adam_update", &spiral_adam_step, "SpiralPipe CPU Adam update (C++) ");
-  m.def("adam_update_copy", &spiral_adam_step_plus_copy,
-        "SpiralPipe CPU Adam update and param copy (C++)");
-  m.def("create_adam", &spiral_create_adam_optimizer,
-        "SpiralPipe CPU Adam (C++)");
-  m.def("destroy_adam", &spiral_destroy_adam_optimizer,
-        "SpiralPipe CPU Adam destroy (C++)");
-  m.def("adam_sync", &spiral_adam_synchronize,
-        "SpiralPipe CPU Adam join threads (C++)");
+  m.def("create_adam", &spiral_create_adam_optimizer, "SpiralPipe CPU Adam (C++)");
+  m.def("destroy_adam", &spiral_destroy_adam_optimizer, "SpiralPipe CPU Adam destroy (C++)");
+  m.def("adam_sync", &spiral_adam_synchronize, "SpiralPipe CPU Adam join threads (C++)");
 }

--- a/csrc/spiral_cpu_adam/cpu_adam.hpp
+++ b/csrc/spiral_cpu_adam/cpu_adam.hpp
@@ -17,9 +17,7 @@ typedef unsigned short ds_half_precision_t;
 
 #define STEP(SPAN)                                                             \
   void Step_##SPAN(float* _params, float* grads, float* _exp_avg,              \
-                   float* _exp_avg_sq, size_t _param_size,                     \
-                   ds_half_precision_t* dev_param = nullptr,                   \
-                   bool half_precision = false);
+                   float* _exp_avg_sq, size_t _param_size);
 
 #define ROLLBACK(SPAN)                                                         \
   void Rollback_##SPAN(float* _params, float* grads, float* _exp_avg,          \
@@ -47,9 +45,7 @@ public:
                 float* grads,
                 float* _exp_avg,
                 float* _exp_avg_sq,
-                size_t param_size,
-                ds_half_precision_t* dev_param = nullptr,
-                bool half_precision = false);
+                size_t param_size);
   
   template <int span>
   void Rollback_AVX(size_t* rounded_size,
@@ -123,16 +119,14 @@ private:
 #if defined(__AVX512__) or defined(__AVX256__)
 template <int span>
 void SpiralAdamOptimizer::Step_AVX(size_t* rounded_size,
-                                     float* _params,
-                                     float* grads,
-                                     float* _exp_avg,
-                                     float* _exp_avg_sq,
-                                     size_t _param_size,
-                                     ds_half_precision_t* dev_params,
-                                     bool half_precision)
+                                   float* _params,
+                                   float* grads,
+                                   float* _exp_avg,
+                                   float* _exp_avg_sq,
+                                   size_t _param_size)
 {
   size_t new_rounded_size = 0;
-  int rshft = half_precision ? 1 : 0;
+  int rshft = 0;
 
   AVX_Data betta1_4;
   betta1_4.data = SIMD_SET(_betta1);
@@ -170,7 +164,7 @@ void SpiralAdamOptimizer::Step_AVX(size_t* rounded_size,
 #pragma omp parallel for
     for (size_t i = t; i < offset; i += SIMD_WIDTH * span) {
       AVX_Data grad_4[span];
-      simd_load<span>(grad_4, grads + (i >> rshft), half_precision);
+      simd_load<span>(grad_4, grads + (i >> rshft), false);
 
       AVX_Data momentum_4[span];
       simd_load<span>(momentum_4, _exp_avg + i, false);
@@ -179,7 +173,7 @@ void SpiralAdamOptimizer::Step_AVX(size_t* rounded_size,
       simd_load<span>(variance_4, _exp_avg_sq + i, false);
 
       AVX_Data param_4[span];
-      simd_load<span>(param_4, _params + (i >> rshft), half_precision);
+      simd_load<span>(param_4, _params + (i >> rshft), false);
 
       if (_weight_decay > 0 && !_adamw_mode) {
         simd_fma<span>(grad_4, param_4, weight_decay4, grad_4);
@@ -200,7 +194,7 @@ void SpiralAdamOptimizer::Step_AVX(size_t* rounded_size,
 
       simd_fma<span>(param_4, grad_4, step_size_4, param_4);
 
-      simd_store<span>(_params + (i >> rshft), param_4, half_precision);
+      simd_store<span>(_params + (i >> rshft), param_4, false);
       simd_store<span>(_exp_avg + i, momentum_4, false);
       simd_store<span>(_exp_avg_sq + i, variance_4, false);
     }
@@ -213,14 +207,11 @@ void SpiralAdamOptimizer::Step_1(float* _params,
                                    float* grads,
                                    float* _exp_avg,
                                    float* _exp_avg_sq,
-                                   size_t _param_size,
-                                   ds_half_precision_t* dev_params,
-                                   bool half_precision)
+                                   size_t _param_size)
 {
   size_t rounded_size = 0;
 #if defined(__AVX512__) or defined(__AVX256__)
-  Step_AVX<1>(&rounded_size, _params, grads, _exp_avg, _exp_avg_sq, _param_size,
-              dev_params, half_precision);
+  Step_AVX<1>(&rounded_size, _params, grads, _exp_avg, _exp_avg_sq, _param_size);
 #endif
   if (_param_size > rounded_size) {
     float betta1_minus1 = 1 - _betta1;
@@ -228,12 +219,6 @@ void SpiralAdamOptimizer::Step_1(float* _params,
 
     float step_size = -1 * _alpha / _bias_correction1;
     float w_decay = -1 * _alpha * _weight_decay;
-    ds_half_precision_t* grads_cast_h;
-    ds_half_precision_t* params_cast_h;
-    if (half_precision) {
-      grads_cast_h = reinterpret_cast<ds_half_precision_t*>(grads);
-      params_cast_h = reinterpret_cast<ds_half_precision_t*>(_params);
-    }
 
     for (size_t t = rounded_size; t < _param_size; t += TILE) {
       size_t copy_size = TILE;
@@ -242,8 +227,8 @@ void SpiralAdamOptimizer::Step_1(float* _params,
       size_t offset = copy_size + t;
 #pragma omp parallel for
       for (size_t k = t; k < offset; k++) {
-        float grad = half_precision ? (float)grads_cast_h[k] : grads[k];
-        float param = half_precision ? (float)params_cast_h[k] : _params[k];
+        float grad = grads[k];
+        float param = _params[k];
         float momentum = _exp_avg[k];
         float variance = _exp_avg_sq[k];
         if (_weight_decay > 0 && !_adamw_mode) {
@@ -263,10 +248,8 @@ void SpiralAdamOptimizer::Step_1(float* _params,
           param += w_decay * param;
         }
         param = grad * step_size + param;
-        if (half_precision)
-          params_cast_h[k] = (ds_half_precision_t)param;
-        else
-          _params[k] = param;
+
+        _params[k] = param;
         _exp_avg[k] = momentum;
         _exp_avg_sq[k] = variance;
       }
@@ -278,42 +261,32 @@ void SpiralAdamOptimizer::Step_4(float* _params,
                                    float* grads,
                                    float* _exp_avg,
                                    float* _exp_avg_sq,
-                                   size_t _param_size,
-                                   ds_half_precision_t* dev_params,
-                                   bool half_precision)
+                                   size_t _param_size)
 {
   size_t rounded_size = 0;
 #if defined(__AVX512__) or defined(__AVX256__)
-  Step_AVX<4>(&rounded_size, _params, grads, _exp_avg, _exp_avg_sq, _param_size,
-              dev_params, half_precision);
+  Step_AVX<4>(&rounded_size, _params, grads, _exp_avg, _exp_avg_sq, _param_size);
 #endif
   if (_param_size > rounded_size)
     Step_1((_params + rounded_size), (grads + rounded_size),
            (_exp_avg + rounded_size), (_exp_avg_sq + rounded_size),
-           (_param_size - rounded_size),
-           (dev_params != nullptr ? (dev_params + rounded_size) : dev_params),
-           half_precision);
+           (_param_size - rounded_size));
 }
 
 void SpiralAdamOptimizer::Step_8(float* _params,
                                    float* grads,
                                    float* _exp_avg,
                                    float* _exp_avg_sq,
-                                   size_t _param_size,
-                                   ds_half_precision_t* dev_params,
-                                   bool half_precision)
+                                   size_t _param_size)
 {
   size_t rounded_size = 0;
 #if defined(__AVX512__) or defined(__AVX256__)
-  Step_AVX<8>(&rounded_size, _params, grads, _exp_avg, _exp_avg_sq, _param_size,
-              dev_params, half_precision);
+  Step_AVX<8>(&rounded_size, _params, grads, _exp_avg, _exp_avg_sq, _param_size);
 #endif
   if (_param_size > rounded_size)
     Step_4((_params + rounded_size), (grads + rounded_size),
            (_exp_avg + rounded_size), (_exp_avg_sq + rounded_size),
-           (_param_size - rounded_size),
-           (dev_params != nullptr ? (dev_params + rounded_size) : dev_params),
-           half_precision);
+           (_param_size - rounded_size));
 }
 
 #if defined(__AVX512__) or defined(__AVX256__)

--- a/csrc/spiral_cpu_adam/cpu_adam.hpp
+++ b/csrc/spiral_cpu_adam/cpu_adam.hpp
@@ -50,6 +50,11 @@ public:
   STEP(1)
   STEP(4)
   STEP(8)
+  void Rollback(float* _params,
+                float* grads,
+                float* _exp_avg,
+                float* _exp_avg_sq,
+                size_t _param_size);
   inline void IncrementStep(size_t step, float beta1, float beta2)
   {
     if (beta1 != _betta1 || beta2 != _betta2) {
@@ -298,4 +303,54 @@ void SpiralAdamOptimizer::Step_8(float* _params,
            (_param_size - rounded_size),
            (dev_params != nullptr ? (dev_params + rounded_size) : dev_params),
            half_precision);
+}
+
+void SpiralAdamOptimizer::Rollback(float* _params,
+                                   float* grads,
+                                   float* _exp_avg,
+                                   float* _exp_avg_sq,
+                                   size_t _param_size)
+{
+  size_t rounded_size = 0;
+
+  float betta1_minus1 = 1 - _betta1;
+  float betta2_minus1 = 1 - _betta2;
+
+  float step_size = -1 * _alpha / _bias_correction1;
+  float w_decay = -1 * _alpha * _weight_decay;
+
+  for (size_t t = rounded_size; t < _param_size; t += TILE) {
+    size_t copy_size = TILE;
+    if ((t + TILE) > _param_size)
+      copy_size = _param_size - t;
+    size_t offset = copy_size + t;
+
+    for (size_t k = t; k < offset; k++) {
+      float grad = grads[k];
+      float param = _params[k];
+      float momentum = _exp_avg[k];
+      float variance = _exp_avg_sq[k];
+
+      float aaa = momentum / (sqrt(variance) * _bias_correction2 + _eps);
+      param = param - aaa * step_size;
+      if (_weight_decay > 0 && _adamw_mode) {
+        param = param / (1 + w_decay);
+      }
+
+      if (_weight_decay > 0 && !_adamw_mode) {
+        grad = param * _weight_decay + grad;
+      }
+
+      momentum = momentum - grad * betta1_minus1;
+      momentum = momentum / _betta1;
+
+      grad = grad * grad;
+      variance = variance - grad * betta2_minus1;
+      variance = variance / _betta2;
+      
+      _params[k] = param;
+      _exp_avg[k] = momentum;
+      _exp_avg_sq[k] = variance;
+    }
+  }
 }

--- a/csrc/spiral_cpu_adam/cpu_adam.hpp
+++ b/csrc/spiral_cpu_adam/cpu_adam.hpp
@@ -376,12 +376,12 @@ void SpiralAdamOptimizer::Rollback_AVX(size_t* rounded_size,
       AVX_Data param_4[span];
       simd_load<span>(param_4, _params + (i >> rshft), false);
 
-      AVX_Data aaa_4[span];
-      simd_sqrt<span>(aaa_4, variance_4);
-      simd_fma<span>(aaa_4, aaa_4, bias2_sqrt, eps_4);
-      simd_div<span>(aaa_4, momentum_4, aaa_4);
+      AVX_Data buf_4[span];
+      simd_sqrt<span>(buf_4, variance_4);
+      simd_fma<span>(buf_4, buf_4, bias2_sqrt, eps_4);
+      simd_div<span>(buf_4, momentum_4, buf_4);
 
-      simd_fma<span>(param_4, aaa_4, minus_step_size_4, param_4);
+      simd_fma<span>(param_4, buf_4, minus_step_size_4, param_4);
 
       if (_weight_decay > 0 && _adamw_mode) {
         simd_div<span>(param_4, param_4, weight_decay4);
@@ -440,8 +440,8 @@ void SpiralAdamOptimizer::Rollback_1(float* _params,
         float momentum = _exp_avg[k];
         float variance = _exp_avg_sq[k];
 
-        float aaa = momentum / (sqrt(variance) * _bias_correction2 + _eps);
-        param = param - aaa * step_size;
+        float buf = momentum / (sqrt(variance) * _bias_correction2 + _eps);
+        param = param - buf * step_size;
         if (_weight_decay > 0 && _adamw_mode) {
           param = param / (1 + w_decay);
         }

--- a/csrc/spiral_cpu_adam/cpu_adam.hpp
+++ b/csrc/spiral_cpu_adam/cpu_adam.hpp
@@ -12,21 +12,8 @@
 #include <cassert>
 #include <stdio.h>
 #include <torch/extension.h>
-
-#if defined(__ENABLE_CUDA__)
-#include "cuda.h"
-#include "custom_cuda_layers.h"
-#include <cuda_fp16.h>
-#include <cuda_runtime_api.h>
-typedef __half ds_half_precision_t;
-#elif defined(__ENABLE_CANN__)
-#include "acl/acl.h"
-#include "torch_npu/csrc/core/npu/NPUStream.h"
-typedef c10::Half ds_half_precision_t;
-#else
 #include <cmath>
 typedef unsigned short ds_half_precision_t;
-#endif
 
 #define STEP(SPAN)                                                             \
   void Step_##SPAN(float* _params, float* grads, float* _exp_avg,              \
@@ -46,30 +33,8 @@ public:
       _weight_decay(weight_decay), _betta1_t(1.0), _betta2_t(1.0), _step(0),
       _adamw_mode(adamw_mode)
   {
-#if defined(__ENABLE_CUDA__)
-    cudaMallocHost((void**)_doubled_buffer, TILE * sizeof(float));
-    cudaMallocHost((void**)(_doubled_buffer + 1), TILE * sizeof(float));
-
-    _streams[0] = TrainingContext::Instance().GetCurrentStream();
-    _streams[1] = TrainingContext::Instance().GetNewStream();
-    _buf_index = false;
-#elif defined(__ENABLE_CANN__)
-    aclrtMallocHost((void**)_doubled_buffer, TILE * sizeof(float));
-    aclrtMallocHost((void**)(_doubled_buffer + 1), TILE * sizeof(float));
-
-    _buf_index = false;
-#endif
   }
-  ~SpiralAdamOptimizer()
-  {
-#if defined(__ENABLE_CUDA__)
-    cudaFreeHost(_doubled_buffer[0]);
-    cudaFreeHost(_doubled_buffer[1]);
-#elif defined(__ENABLE_CANN__)
-    aclrtFreeHost(_doubled_buffer[0]);
-    aclrtFreeHost(_doubled_buffer[1]);
-#endif
-  }
+  ~SpiralAdamOptimizer() {}
 
 #if defined(__AVX512__) or defined(__AVX256__)
   template <int span>
@@ -85,19 +50,6 @@ public:
   STEP(1)
   STEP(4)
   STEP(8)
-#if defined(__ENABLE_CUDA__)
-  inline void SynchronizeStreams()
-  {
-    for (int i = 0; i < 2; i++)
-      cudaStreamSynchronize(_streams[i]);
-  }
-#elif defined(__ENABLE_CANN__)
-  inline void SynchronizeStreams()
-  {
-    for (int i = 0; i < 2; i++)
-      aclrtSynchronizeStream(_streams[i].stream());
-  }
-#endif
   inline void IncrementStep(size_t step, float beta1, float beta2)
   {
     if (beta1 != _betta1 || beta2 != _betta2) {
@@ -150,17 +102,6 @@ private:
   float _bias_correction2;
 
   bool _adamw_mode;
-
-#if defined(__ENABLE_CUDA__)
-  float* _doubled_buffer[2];
-  cudaStream_t _streams[2];
-  bool _buf_index;
-#elif defined(__ENABLE_CANN__)
-  float* _doubled_buffer[2];
-  c10_npu::NPUStream _streams[2] = { c10_npu::getCurrentNPUStream(),
-                                     c10_npu::getNPUStreamFromPool() };
-  bool _buf_index;
-#endif
 };
 
 #if defined(__AVX512__) or defined(__AVX256__)
@@ -210,15 +151,6 @@ void SpiralAdamOptimizer::Step_AVX(size_t* rounded_size,
     if ((t + TILE) > new_rounded_size)
       copy_size = new_rounded_size - t;
     size_t offset = copy_size + t;
-#if defined(__ENABLE_CUDA__)
-    if ((t / TILE) >= 2) {
-      cudaStreamSynchronize(_streams[_buf_index]);
-    }
-#elif defined(__ENABLE_CANN__)
-    if ((t / TILE) >= 2) {
-      aclrtSynchronizeStream(_streams[_buf_index].stream());
-    }
-#endif
 #pragma omp parallel for
     for (size_t i = t; i < offset; i += SIMD_WIDTH * span) {
       AVX_Data grad_4[span];
@@ -253,37 +185,9 @@ void SpiralAdamOptimizer::Step_AVX(size_t* rounded_size,
       simd_fma<span>(param_4, grad_4, step_size_4, param_4);
 
       simd_store<span>(_params + (i >> rshft), param_4, half_precision);
-#if defined(__ENABLE_CUDA__) or defined(__ENABLE_CANN__)
-      if (dev_params) {
-        simd_store<span>(_doubled_buffer[_buf_index] + (i - t), param_4,
-                         half_precision);
-      }
-#endif
       simd_store<span>(_exp_avg + i, momentum_4, false);
       simd_store<span>(_exp_avg_sq + i, variance_4, false);
     }
-#if defined(__ENABLE_CUDA__)
-    if (dev_params) {
-      if (half_precision)
-        launch_param_update_half(_doubled_buffer[_buf_index], dev_params + t,
-                                 copy_size, _streams[_buf_index]);
-      else
-        launch_param_update(_doubled_buffer[_buf_index], dev_params + t,
-                            copy_size, _streams[_buf_index]);
-
-      _buf_index = !_buf_index;
-    }
-#elif defined(__ENABLE_CANN__)
-    if (dev_params) {
-      size_t memcpy_size = copy_size * sizeof(_doubled_buffer[_buf_index][0]);
-      if (half_precision)
-        memcpy_size /= 2;
-      aclrtMemcpy(dev_params + t, memcpy_size, _doubled_buffer[_buf_index],
-                  memcpy_size, aclrtMemcpyKind::ACL_MEMCPY_HOST_TO_DEVICE);
-
-      _buf_index = !_buf_index;
-    }
-#endif
   }
   *rounded_size = new_rounded_size;
 }
@@ -320,15 +224,6 @@ void SpiralAdamOptimizer::Step_1(float* _params,
       if ((t + TILE) > _param_size)
         copy_size = _param_size - t;
       size_t offset = copy_size + t;
-#if defined(__ENABLE_CUDA__)
-      if ((t / TILE) >= 2) {
-        cudaStreamSynchronize(_streams[_buf_index]);
-      }
-#elif defined(__ENABLE_CANN__)
-      if ((t / TILE) >= 2) {
-        aclrtSynchronizeStream(_streams[_buf_index].stream());
-      }
-#endif
 #pragma omp parallel for
       for (size_t k = t; k < offset; k++) {
         float grad = half_precision ? (float)grads_cast_h[k] : grads[k];
@@ -352,10 +247,6 @@ void SpiralAdamOptimizer::Step_1(float* _params,
           param += w_decay * param;
         }
         param = grad * step_size + param;
-#if defined(__ENABLE_CUDA__) or defined(__ENABLE_CANN__)
-        if (dev_params)
-          _doubled_buffer[_buf_index][k - t] = param;
-#endif
         if (half_precision)
           params_cast_h[k] = (ds_half_precision_t)param;
         else
@@ -363,22 +254,6 @@ void SpiralAdamOptimizer::Step_1(float* _params,
         _exp_avg[k] = momentum;
         _exp_avg_sq[k] = variance;
       }
-#if defined(__ENABLE_CUDA__)
-      if (dev_params) {
-        launch_param_update(_doubled_buffer[_buf_index], dev_params + t,
-                            (copy_size), _streams[_buf_index]);
-
-        _buf_index = !_buf_index;
-      }
-#elif defined(__ENABLE_CANN__)
-      if (dev_params) {
-        size_t memcpy_size = copy_size * sizeof(_doubled_buffer[_buf_index][0]);
-        aclrtMemcpy(dev_params + t, memcpy_size, _doubled_buffer[_buf_index],
-                    memcpy_size, aclrtMemcpyKind::ACL_MEMCPY_HOST_TO_DEVICE);
-
-        _buf_index = !_buf_index;
-      }
-#endif
     }
   }
 }

--- a/csrc/spiral_cpu_adam/cpu_adam.hpp
+++ b/csrc/spiral_cpu_adam/cpu_adam.hpp
@@ -8,7 +8,7 @@
 #define NOMINMAX // Windows idiosyncrasy
                  // https://stackoverflow.com/questions/4913922/possible-problems-with-nominmax-on-visual-c
 
-#include "simd.h"
+#include "simd.hpp"
 #include <cassert>
 #include <stdio.h>
 #include <torch/extension.h>
@@ -20,6 +20,10 @@ typedef unsigned short ds_half_precision_t;
                    float* _exp_avg_sq, size_t _param_size,                     \
                    ds_half_precision_t* dev_param = nullptr,                   \
                    bool half_precision = false);
+
+#define ROLLBACK(SPAN)                                                         \
+  void Rollback_##SPAN(float* _params, float* grads, float* _exp_avg,          \
+                       float* _exp_avg_sq, size_t _param_size);
 
 class SpiralAdamOptimizer {
 public:
@@ -46,15 +50,22 @@ public:
                 size_t param_size,
                 ds_half_precision_t* dev_param = nullptr,
                 bool half_precision = false);
+  
+  template <int span>
+  void Rollback_AVX(size_t* rounded_size,
+                    float* _params,
+                    float* grads,
+                    float* _exp_avg,
+                    float* _exp_avg_sq,
+                    size_t _param_size);
 #endif
+
   STEP(1)
   STEP(4)
   STEP(8)
-  void Rollback(float* _params,
-                float* grads,
-                float* _exp_avg,
-                float* _exp_avg_sq,
-                size_t _param_size);
+  ROLLBACK(1)
+  ROLLBACK(4)
+  ROLLBACK(8)
   inline void IncrementStep(size_t step, float beta1, float beta2)
   {
     if (beta1 != _betta1 || beta2 != _betta2) {
@@ -305,57 +316,188 @@ void SpiralAdamOptimizer::Step_8(float* _params,
            half_precision);
 }
 
-void SpiralAdamOptimizer::Rollback(float* _params,
-                                   float* grads,
-                                   float* _exp_avg,
-                                   float* _exp_avg_sq,
-                                   size_t _param_size)
+#if defined(__AVX512__) or defined(__AVX256__)
+template <int span>
+void SpiralAdamOptimizer::Rollback_AVX(size_t* rounded_size,
+                                       float* _params,
+                                       float* grads,
+                                       float* _exp_avg,
+                                       float* _exp_avg_sq,
+                                       size_t _param_size)
 {
-  size_t rounded_size = 0;
+  size_t new_rounded_size = 0;
+  int rshft = 0;
+
+  AVX_Data betta1_4;
+  betta1_4.data = SIMD_SET(_betta1);
+  AVX_Data betta2_4;
+  betta2_4.data = SIMD_SET(_betta2);
 
   float betta1_minus1 = 1 - _betta1;
   float betta2_minus1 = 1 - _betta2;
+  AVX_Data minus_betta1_minus1_4;
+  minus_betta1_minus1_4.data = SIMD_SET(betta1_minus1 * -1);
+  AVX_Data minus_betta2_minus1_4;
+  minus_betta2_minus1_4.data = SIMD_SET(betta2_minus1 * -1);
+
+  AVX_Data bias2_sqrt;
+  bias2_sqrt.data = SIMD_SET(_bias_correction2);
+
+  AVX_Data eps_4;
+  eps_4.data = SIMD_SET(_eps);
 
   float step_size = -1 * _alpha / _bias_correction1;
-  float w_decay = -1 * _alpha * _weight_decay;
+  AVX_Data minus_step_size_4;
+  minus_step_size_4.data = SIMD_SET(step_size * -1);
 
-  for (size_t t = rounded_size; t < _param_size; t += TILE) {
+  float w_decay_plus1 = -1 * _alpha * _weight_decay + 1;
+  AVX_Data weight_decay4;
+  if (_weight_decay > 0)
+    weight_decay4.data =
+        (_adamw_mode ? SIMD_SET(w_decay_plus1) : SIMD_SET(_weight_decay));
+  new_rounded_size = ROUND_DOWN(_param_size, SIMD_WIDTH * span);
+  for (size_t t = 0; t < new_rounded_size; t += TILE) {
     size_t copy_size = TILE;
-    if ((t + TILE) > _param_size)
-      copy_size = _param_size - t;
+    if ((t + TILE) > new_rounded_size)
+      copy_size = new_rounded_size - t;
     size_t offset = copy_size + t;
 
-    for (size_t k = t; k < offset; k++) {
-      float grad = grads[k];
-      float param = _params[k];
-      float momentum = _exp_avg[k];
-      float variance = _exp_avg_sq[k];
+#pragma omp parallel for
+    for (size_t i = t; i < offset; i += SIMD_WIDTH * span) {
+      AVX_Data grad_4[span];
+      simd_load<span>(grad_4, grads + (i >> rshft), false);
 
-      float aaa = momentum / (sqrt(variance) * _bias_correction2 + _eps);
-      param = param - aaa * step_size;
+      AVX_Data momentum_4[span];
+      simd_load<span>(momentum_4, _exp_avg + i, false);
+
+      AVX_Data variance_4[span];
+      simd_load<span>(variance_4, _exp_avg_sq + i, false);
+
+      AVX_Data param_4[span];
+      simd_load<span>(param_4, _params + (i >> rshft), false);
+
+      AVX_Data aaa_4[span];
+      simd_sqrt<span>(aaa_4, variance_4);
+      simd_fma<span>(aaa_4, aaa_4, bias2_sqrt, eps_4);
+      simd_div<span>(aaa_4, momentum_4, aaa_4);
+
+      simd_fma<span>(param_4, aaa_4, minus_step_size_4, param_4);
+
       if (_weight_decay > 0 && _adamw_mode) {
-        param = param / (1 + w_decay);
+        simd_div<span>(param_4, param_4, weight_decay4);
       }
 
       if (_weight_decay > 0 && !_adamw_mode) {
-        grad = param * _weight_decay + grad;
+        simd_fma<span>(grad_4, param_4, weight_decay4, grad_4);
       }
 
-      momentum = momentum - grad * betta1_minus1;
-      momentum = momentum / _betta1;
+      simd_fma<span>(momentum_4, grad_4, minus_betta1_minus1_4, momentum_4);
+      simd_div<span>(momentum_4, momentum_4, betta1_4);
 
-      grad = grad * grad;
-      variance = variance - grad * betta2_minus1;
-      variance = variance / _betta2;
-      
+      simd_mul<span>(grad_4, grad_4, grad_4);
+      simd_fma<span>(variance_4, grad_4, minus_betta2_minus1_4, variance_4);
+      simd_div<span>(variance_4, variance_4, betta2_4);
+
       // If the fp32 precision error is negative, the sqrt operation will result in nan
-      if (variance < 0) {
-        variance = 0;
-      }
+      simd_negative_to_zero<span>(variance_4);
 
-      _params[k] = param;
-      _exp_avg[k] = momentum;
-      _exp_avg_sq[k] = variance;
+      simd_store<span>(_params + (i >> rshft), param_4, false);
+      simd_store<span>(_exp_avg + i, momentum_4, false);
+      simd_store<span>(_exp_avg_sq + i, variance_4, false);
     }
   }
+  *rounded_size = new_rounded_size;
+}
+#endif
+
+void SpiralAdamOptimizer::Rollback_1(float* _params,
+                                     float* grads,
+                                     float* _exp_avg,
+                                     float* _exp_avg_sq,
+                                     size_t _param_size)
+{
+  size_t rounded_size = 0;
+#if defined(__AVX512__) or defined(__AVX256__)
+  Rollback_AVX<1>(&rounded_size, _params, grads, _exp_avg, _exp_avg_sq, _param_size);
+#endif
+
+  if(_param_size > rounded_size) {
+    float betta1_minus1 = 1 - _betta1;
+    float betta2_minus1 = 1 - _betta2;
+
+    float step_size = -1 * _alpha / _bias_correction1;
+    float w_decay = -1 * _alpha * _weight_decay;
+
+    for (size_t t = rounded_size; t < _param_size; t += TILE) {
+      size_t copy_size = TILE;
+      if ((t + TILE) > _param_size)
+        copy_size = _param_size - t;
+      size_t offset = copy_size + t;
+#pragma omp parallel for
+      for (size_t k = t; k < offset; k++) {
+        float grad = grads[k];
+        float param = _params[k];
+        float momentum = _exp_avg[k];
+        float variance = _exp_avg_sq[k];
+
+        float aaa = momentum / (sqrt(variance) * _bias_correction2 + _eps);
+        param = param - aaa * step_size;
+        if (_weight_decay > 0 && _adamw_mode) {
+          param = param / (1 + w_decay);
+        }
+
+        if (_weight_decay > 0 && !_adamw_mode) {
+          grad = param * _weight_decay + grad;
+        }
+
+        momentum = momentum - grad * betta1_minus1;
+        momentum = momentum / _betta1;
+
+        grad = grad * grad;
+        variance = variance - grad * betta2_minus1;
+        variance = variance / _betta2;
+
+        // If the fp32 precision error is negative, the sqrt operation will result in nan
+        if (variance < 0) {
+          variance = 0;
+        }
+
+        _params[k] = param;
+        _exp_avg[k] = momentum;
+        _exp_avg_sq[k] = variance;
+      }
+    }
+  }
+}
+
+void SpiralAdamOptimizer::Rollback_4(float* _params,
+                                     float* grads,
+                                     float* _exp_avg,
+                                     float* _exp_avg_sq,
+                                     size_t _param_size)
+{
+  size_t rounded_size = 0;
+#if defined(__AVX512__) or defined(__AVX256__)
+  Rollback_AVX<4>(&rounded_size, _params, grads, _exp_avg, _exp_avg_sq, _param_size);
+#endif
+  if (_param_size > rounded_size)
+    Rollback_1((_params + rounded_size), (grads + rounded_size),
+               (_exp_avg + rounded_size), (_exp_avg_sq + rounded_size),
+               (_param_size - rounded_size));
+}
+
+void SpiralAdamOptimizer::Rollback_8(float* _params,
+                                     float* grads,
+                                     float* _exp_avg,
+                                     float* _exp_avg_sq,
+                                     size_t _param_size)
+{
+  size_t rounded_size = 0;
+#if defined(__AVX512__) or defined(__AVX256__)
+  Rollback_AVX<8>(&rounded_size, _params, grads, _exp_avg, _exp_avg_sq, _param_size);
+#endif
+  if (_param_size > rounded_size)
+    Rollback_4((_params + rounded_size), (grads + rounded_size),
+               (_exp_avg + rounded_size), (_exp_avg_sq + rounded_size),
+               (_param_size - rounded_size));
 }

--- a/csrc/spiral_cpu_adam/cpu_adam.hpp
+++ b/csrc/spiral_cpu_adam/cpu_adam.hpp
@@ -348,6 +348,11 @@ void SpiralAdamOptimizer::Rollback(float* _params,
       variance = variance - grad * betta2_minus1;
       variance = variance / _betta2;
       
+      // If the fp32 precision error is negative, the sqrt operation will result in nan
+      if (variance < 0) {
+        variance = 0;
+      }
+
       _params[k] = param;
       _exp_avg[k] = momentum;
       _exp_avg_sq[k] = variance;

--- a/csrc/spiral_cpu_adam/simd.hpp
+++ b/csrc/spiral_cpu_adam/simd.hpp
@@ -1,0 +1,140 @@
+// Copyright (c) Microsoft Corporation.
+// SPDX-License-Identifier: Apache-2.0
+
+// DeepSpeed Team
+
+#pragma once
+
+#if (__x86_64__ || __i386__)
+#include <cpuid.h>
+#include <x86intrin.h>
+#endif
+
+#define TILE (128 * 1024 * 1024)
+#if defined(__AVX512__) or defined(__AVX256__)
+
+#define ROUND_DOWN(size, step) ((size) & ~((step)-1))
+
+#if defined(__AVX512__)
+#define SIMD_STORE(a, d) _mm512_storeu_ps(a, d)
+#define SIMD_LOAD(x) _mm512_loadu_ps(x)
+#define SIMD_SET(x) _mm512_set1_ps(x)
+#define SIMD_ADD(x, y) _mm512_add_ps(x, y)
+#define SIMD_MUL(x, y) _mm512_mul_ps(x, y)
+#define SIMD_FMA(x, y, c) _mm512_fmadd_ps(x, y, c)
+#define SIMD_SQRT(x) _mm512_sqrt_ps(x)
+#define SIMD_DIV(x, y) _mm512_div_ps(x, y)
+#define SIMD_WIDTH 16
+
+#define SIMD_LOAD2(x, h) \
+    ((h) ? _mm512_cvtph_ps(_mm256_castps_si256(_mm256_loadu_ps(x))) : _mm512_loadu_ps(x))
+#define SIMD_STORE2(x, d, h)                                                                      \
+    ((h) ? _mm256_store_ps(x, _mm256_castsi256_ps(_mm512_cvtps_ph(d, _MM_FROUND_TO_NEAREST_INT))) \
+         : _mm512_storeu_ps(x, d))
+
+#define INTV __m256i
+#elif defined(__AVX256__)
+#define SIMD_STORE(a, d) _mm256_storeu_ps(a, d)
+#define SIMD_LOAD(x) _mm256_loadu_ps(x)
+#define SIMD_SET(x) _mm256_set1_ps(x)
+#define SIMD_ADD(x, y) _mm256_add_ps(x, y)
+#define SIMD_MUL(x, y) _mm256_mul_ps(x, y)
+#define SIMD_FMA(x, y, c) _mm256_fmadd_ps(x, y, c)
+#define SIMD_SQRT(x) _mm256_sqrt_ps(x)
+#define SIMD_DIV(x, y) _mm256_div_ps(x, y)
+#define SIMD_WIDTH 8
+#define SIMD_LOAD2(x, h) \
+    ((h) ? _mm256_cvtph_ps(_mm_loadu_si128((const __m128i*)x)) : _mm256_loadu_ps(x))
+
+#define SIMD_STORE2(x, d, h)                                                                \
+    ((h) ? _mm_store_ps(x, _mm_castsi128_ps(_mm256_cvtps_ph(d, _MM_FROUND_TO_NEAREST_INT))) \
+         : _mm256_storeu_ps(x, d))
+
+#define INTV __m128i
+#endif
+
+union AVX_Data {
+#if defined(__AVX512__)
+    __m512 data;
+#elif defined(__AVX256__)
+    __m256 data;
+#endif
+    // float data_f[16];
+};
+
+template <int span>
+inline void simd_store(float* dst, AVX_Data* src, bool half_precision)
+{
+    size_t width = (half_precision ? SIMD_WIDTH / 2 : SIMD_WIDTH);
+#pragma unroll
+    for (size_t i = 0; i < span; ++i) { SIMD_STORE2(dst + width * i, src[i].data, half_precision); }
+}
+template <int span>
+inline void simd_load(AVX_Data* dst, float* src, bool half_precision)
+{
+    size_t width = (half_precision ? 1 : SIMD_WIDTH);
+#pragma unroll
+    for (size_t i = 0; i < span; ++i) { dst[i].data = SIMD_LOAD2(src + width * i, half_precision); }
+}
+template <int span>
+inline void simd_fma(AVX_Data* dst, AVX_Data* src_m_l, AVX_Data src_m_r, AVX_Data* src_a)
+{
+#pragma unroll
+    for (size_t i = 0; i < span; ++i) {
+        dst[i].data = SIMD_FMA(src_m_l[i].data, src_m_r.data, src_a[i].data);
+    }
+}
+template <int span>
+inline void simd_fma(AVX_Data* dst, AVX_Data* src_m_l, AVX_Data src_m_r, AVX_Data src_a)
+{
+#pragma unroll
+    for (size_t i = 0; i < span; ++i) {
+        dst[i].data = SIMD_FMA(src_m_l[i].data, src_m_r.data, src_a.data);
+    }
+}
+template <int span>
+inline void simd_fma(AVX_Data* dst, AVX_Data* src_m_l, AVX_Data* src_m_r, AVX_Data* src_a)
+{
+#pragma unroll
+    for (size_t i = 0; i < span; ++i) {
+        dst[i].data = SIMD_FMA(src_m_l[i].data, src_m_r[i].data, src_a[i].data);
+    }
+}
+template <int span>
+inline void simd_sqrt(AVX_Data* dst, AVX_Data* src)
+{
+#pragma unroll
+    for (size_t i = 0; i < span; ++i) { dst[i].data = SIMD_SQRT(src[i].data); }
+}
+template <int span>
+inline void simd_add(AVX_Data* dst, AVX_Data* src_a_l, AVX_Data src_a_r)
+{
+#pragma unroll
+    for (size_t i = 0; i < span; ++i) { dst[i].data = SIMD_ADD(src_a_l[i].data, src_a_r.data); }
+}
+template <int span>
+inline void simd_add(AVX_Data* dst, AVX_Data* src_a_l, AVX_Data* src_a_r)
+{
+#pragma unroll
+    for (size_t i = 0; i < span; ++i) { dst[i].data = SIMD_ADD(src_a_l[i].data, src_a_r[i].data); }
+}
+template <int span>
+inline void simd_mul(AVX_Data* dst, AVX_Data* src_a_l, AVX_Data src_a_r)
+{
+#pragma unroll
+    for (size_t i = 0; i < span; ++i) { dst[i].data = SIMD_MUL(src_a_l[i].data, src_a_r.data); }
+}
+template <int span>
+inline void simd_mul(AVX_Data* dst, AVX_Data* src_a_l, AVX_Data* src_a_r)
+{
+#pragma unroll
+    for (size_t i = 0; i < span; ++i) { dst[i].data = SIMD_MUL(src_a_l[i].data, src_a_r[i].data); }
+}
+template <int span>
+inline void simd_div(AVX_Data* dst, AVX_Data* src_a_l, AVX_Data* src_a_r)
+{
+#pragma unroll
+    for (size_t i = 0; i < span; ++i) { dst[i].data = SIMD_DIV(src_a_l[i].data, src_a_r[i].data); }
+}
+
+#endif

--- a/csrc/spiral_cpu_adam/simd.hpp
+++ b/csrc/spiral_cpu_adam/simd.hpp
@@ -24,6 +24,8 @@
 #define SIMD_FMA(x, y, c) _mm512_fmadd_ps(x, y, c)
 #define SIMD_SQRT(x) _mm512_sqrt_ps(x)
 #define SIMD_DIV(x, y) _mm512_div_ps(x, y)
+#define SIMD_AND(x, y) _mm512_and_ps(x, y)
+#define SIMD_CMP_LT(x, y) _mm512_cmp_ps(x, y, _CMP_LT_OQ)
 #define SIMD_WIDTH 16
 
 #define SIMD_LOAD2(x, h) \
@@ -42,7 +44,10 @@
 #define SIMD_FMA(x, y, c) _mm256_fmadd_ps(x, y, c)
 #define SIMD_SQRT(x) _mm256_sqrt_ps(x)
 #define SIMD_DIV(x, y) _mm256_div_ps(x, y)
+#define SIMD_AND(x, y) _mm256_and_ps(x, y)
+#define SIMD_CMP_LT(x, y) _mm256_cmp_ps(x, y, _CMP_LT_OQ)
 #define SIMD_WIDTH 8
+
 #define SIMD_LOAD2(x, h) \
     ((h) ? _mm256_cvtph_ps(_mm_loadu_si128((const __m128i*)x)) : _mm256_loadu_ps(x))
 
@@ -131,10 +136,28 @@ inline void simd_mul(AVX_Data* dst, AVX_Data* src_a_l, AVX_Data* src_a_r)
     for (size_t i = 0; i < span; ++i) { dst[i].data = SIMD_MUL(src_a_l[i].data, src_a_r[i].data); }
 }
 template <int span>
+inline void simd_div(AVX_Data* dst, AVX_Data* src_a_l, AVX_Data src_a_r)
+{
+#pragma unroll
+    for (size_t i = 0; i < span; ++i) { dst[i].data = SIMD_DIV(src_a_l[i].data, src_a_r.data); }
+}
+template <int span>
 inline void simd_div(AVX_Data* dst, AVX_Data* src_a_l, AVX_Data* src_a_r)
 {
 #pragma unroll
     for (size_t i = 0; i < span; ++i) { dst[i].data = SIMD_DIV(src_a_l[i].data, src_a_r[i].data); }
+}
+template <int span>
+inline void simd_negative_to_zero(AVX_Data* src)
+{
+#pragma unroll
+    for (size_t i = 0; i < span; ++i) {
+        AVX_Data _zero;
+        _zero.data = SIMD_SET(0.0);
+        AVX_Data _positive_mask;
+        _positive_mask.data = SIMD_CMP_LT(_zero.data, src[i].data);
+        src[i].data = SIMD_AND(src[i].data, _positive_mask.data);
+    }
 }
 
 #endif

--- a/megatron/spiral/optimizer/cpu_adam.py
+++ b/megatron/spiral/optimizer/cpu_adam.py
@@ -254,3 +254,51 @@ class SpiralCPUAdam(torch.optim.Optimizer):
         if found_inf is None:
             found_inf = torch.FloatTensor([0])
         self.ds_opt_adam.adam_sync(self.opt_id, found_inf)
+
+    @torch.no_grad()
+    def rollback(self):
+        """Rollback the model parameters."""
+
+        # intended device for step
+        device = torch.device("cpu")
+
+        param_idx = -1
+        for group_id, group in enumerate(self.param_groups):
+            for param_id, p in enumerate(group["params"]):
+                param_idx += 1
+
+                if p.grad is None:
+                    print(f"[Warning] Optimizer#{self.opt_id} skipped grp#{group_id} param#{param_id} step due to grad={p.grad}")
+                    continue
+
+                assert p.device == device, (
+                    f"CPUAdam param is on {p.device} and must be 'cpu', make "
+                    "sure you enabled 'offload_optimizer': 'cpu' in your ZeRO config."
+                )
+
+                state = self.state[p]
+                assert len(state) != 0, "Rollback should be call after run optimizer.step"
+
+                beta1, beta2 = group["betas"]
+
+                self.ds_opt_adam.adam_rollback(
+                    self.opt_id,
+                    group_id,
+                    param_idx,
+                    state["step"],
+                    group["lr"],
+                    beta1,
+                    beta2,
+                    group["eps"],
+                    group["weight_decay"],
+                    group["bias_correction"],
+                    p.data,
+                    p.grad.data,
+                    state["exp_avg"],
+                    state["exp_avg_sq"],
+                    self.inv_scale,
+                    self.half_precision,
+                    -1
+                )
+
+                state["step"] -= 1

--- a/megatron/spiral/optimizer/cpu_adam.py
+++ b/megatron/spiral/optimizer/cpu_adam.py
@@ -118,6 +118,7 @@ class SpiralCPUAdam(torch.optim.Optimizer):
         )
         self.inv_scale = 0
         self.ev_long = -1
+        self.optimizer_locked = False
 
     def __del__(self):
         # need to destroy the C++ object explicitly to avoid a memory leak when deepspeed.initialize
@@ -130,7 +131,7 @@ class SpiralCPUAdam(torch.optim.Optimizer):
             group.setdefault("amsgrad", False)
 
     @torch.no_grad()
-    def step(self, closure=None, fp16_param_groups=None):
+    def step(self, sync=False, found_inf=None, closure=None):
         """Update the model parameters.
 
         .. note::
@@ -140,11 +141,12 @@ class SpiralCPUAdam(torch.optim.Optimizer):
             <https://www.deepspeed.ai/getting-started/#training>`_ guide.
 
         Args:
+            sync: wait until all parameter rollbacks are completed.
+                Defaults to ``False``.
+            found_inf: check for inf/nan when using mixed precision.
+                Valid only when sync is ``True``.
             closure (callable, optional): closure to compute the loss.
                 Defaults to ``None``.
-            fp16_param_groups: FP16 GPU parameters to update. Performing the
-                copy here reduces communication time. Defaults to ``None``.
-            offload_grad_ev: Gradient offload event to synchronize before using grads to update weights
 
         Returns:
             loss: if ``closure`` is provided. Otherwise ``None``.
@@ -158,12 +160,9 @@ class SpiralCPUAdam(torch.optim.Optimizer):
         # intended device for step
         device = torch.device("cpu")
 
-        # converting the fp16 params to a group of parameter
-        if type(fp16_param_groups) is list:
-            if type(fp16_param_groups[0]) is not list:
-                fp16_param_groups = [fp16_param_groups]
-        elif fp16_param_groups is not None:
-            fp16_param_groups = [[fp16_param_groups]]
+        # step after all threads are synced
+        assert(self.optimizer_locked == False)
+        self.optimizer_locked = True
 
         param_idx = -1
         for group_id, group in enumerate(self.param_groups):
@@ -202,65 +201,46 @@ class SpiralCPUAdam(torch.optim.Optimizer):
                 state["step"] += 1
                 beta1, beta2 = group["betas"]
 
-                if fp16_param_groups is not None:
-                    self.ds_opt_adam.adam_update_copy(
-                        self.opt_id,
-                        group_id,
-                        state["step"],
-                        group["lr"],
-                        beta1,
-                        beta2,
-                        group["eps"],
-                        group["weight_decay"],
-                        group["bias_correction"],
-                        p.data,
-                        p.grad.data,
-                        state["exp_avg"],
-                        state["exp_avg_sq"],
-                        fp16_param_groups[group_id][param_id].data,
-                        self.ev_long,
-                    )
-                else:
-                    self.ds_opt_adam.adam_update(
-                        self.opt_id,
-                        group_id,
-                        param_idx,
-                        state["step"],
-                        group["lr"],
-                        beta1,
-                        beta2,
-                        group["eps"],
-                        group["weight_decay"],
-                        group["bias_correction"],
-                        p.data,
-                        p.grad.data,
-                        state["exp_avg"],
-                        state["exp_avg_sq"],
-                        self.inv_scale,
-                        self.half_precision,
-                        self.ev_long,
-                    )
+                self.ds_opt_adam.adam_update(
+                    self.opt_id,
+                    group_id,
+                    param_idx,
+                    state["step"],
+                    group["lr"],
+                    beta1,
+                    beta2,
+                    group["eps"],
+                    group["weight_decay"],
+                    group["bias_correction"],
+                    p.data,
+                    p.grad.data,
+                    state["exp_avg"],
+                    state["exp_avg_sq"],
+                    self.inv_scale,
+                    self.half_precision,
+                    self.ev_long,
+                )
+
+        if sync:
+            self.sync(found_inf)
 
         return loss
 
-    def set_inv_scale(self, inv_scale):
-        self.inv_scale = inv_scale
-
-    def set_event_long(self, ev_long):
-        self.ev_long = ev_long
-
-    def sync(self, found_inf=None):
-        # Need to sync until all thread optimizer completed
-        if found_inf is None:
-            found_inf = torch.FloatTensor([0])
-        self.ds_opt_adam.adam_sync(self.opt_id, found_inf)
-
     @torch.no_grad()
-    def rollback(self):
-        """Rollback the model parameters."""
+    def rollback(self, sync=False):
+        """Rollback the model parameters.
+        
+        Args:
+            sync: wait until all parameter rollbacks are completed.
+                Defaults to ``False``.
+        """
 
         # intended device for step
         device = torch.device("cpu")
+
+        # rollback after all threads are synced
+        assert(self.optimizer_locked == False)
+        self.optimizer_locked = True
 
         param_idx = -1
         for group_id, group in enumerate(self.param_groups):
@@ -302,3 +282,19 @@ class SpiralCPUAdam(torch.optim.Optimizer):
                 )
 
                 state["step"] -= 1
+
+        if sync:
+            self.sync()
+
+    def sync(self, found_inf=None):
+        # Need to sync until all thread optimizer completed
+        if found_inf is None:
+            found_inf = torch.FloatTensor([0])
+        self.ds_opt_adam.adam_sync(self.opt_id, found_inf)
+        self.optimizer_locked = False
+
+    def set_inv_scale(self, inv_scale):
+        self.inv_scale = inv_scale
+
+    def set_event_long(self, ev_long):
+        self.ev_long = ev_long

--- a/megatron/spiral/optimizer/stage_optimizer.py
+++ b/megatron/spiral/optimizer/stage_optimizer.py
@@ -94,7 +94,7 @@ class SpiralStageOptimizer:
         # rollback
         if found_inf_flag:
             for optimizer in self.optimizer_list:
-                optimizer.optimizer.rollback()
+                optimizer.optimizer.rollback(sync=True)
 
         spiral_stage_optimizer_step_returns.appendleft((not found_inf_flag, None, None))
 

--- a/megatron/spiral/optimizer/stage_optimizer.py
+++ b/megatron/spiral/optimizer/stage_optimizer.py
@@ -84,6 +84,11 @@ class SpiralStageOptimizer:
             self.grad_scaler.update(found_inf_flag)
             self.inv_scale_val = self.grad_scaler.inv_scale.item()
 
+        # rollback
+        if found_inf_flag:
+            for optimizer in self.optimizer_list:
+                optimizer.optimizer.rollback()
+
         spiral_stage_optimizer_step_returns.appendleft((not found_inf_flag, None, None))
 
         return self._process_step_returns(spiral_stage_optimizer_step_returns)

--- a/megatron/spiral/optimizer/stage_optimizer.py
+++ b/megatron/spiral/optimizer/stage_optimizer.py
@@ -2,6 +2,7 @@ from collections import deque
 import nvtx
 import torch
 
+from megatron.core import mpu
 from megatron.spiral.initialize import get_thunder_cuda_manager
 
 class SpiralStageOptimizer:
@@ -43,11 +44,6 @@ class SpiralStageOptimizer:
 
     param_groups = property(_get_param_groups)
 
-    def update_grad_scaler(self, found_inf):
-        if self.grad_scaler != None:
-            self.grad_scaler.update(found_inf)
-            self.inv_scale_val = self.grad_scaler.inv_scale.item()
-
     def get_loss_scale(self):
         return self.grad_scaler.scale
     
@@ -68,11 +64,27 @@ class SpiralStageOptimizer:
     @nvtx.annotate("join_step", color="red")
     def join_step(self):
         spiral_stage_optimizer_step_returns = deque()
+        local_found_inf = 0
+        found_inf_flag = False
+
+        # sync all optimizers
         for optimizer in reversed(self.optimizer_list):
             found_inf = torch.FloatTensor([0])
             optimizer.optimizer.sync(found_inf)
-            self.update_grad_scaler(found_inf.item() > 0)
-            spiral_stage_optimizer_step_returns.appendleft((found_inf.item() == 0, None, None))
+            local_found_inf += found_inf.item()
+
+        # update grad scaler
+        if self.grad_scaler:
+            found_inf = torch.cuda.FloatTensor([local_found_inf])
+            torch.distributed.all_reduce(found_inf,
+                                         op=torch.distributed.ReduceOp.MAX,
+                                         group=mpu.get_model_parallel_group())
+            found_inf_flag = (found_inf.item() > 0)
+
+            self.grad_scaler.update(found_inf_flag)
+            self.inv_scale_val = self.grad_scaler.inv_scale.item()
+
+        spiral_stage_optimizer_step_returns.appendleft((not found_inf_flag, None, None))
 
         return self._process_step_returns(spiral_stage_optimizer_step_returns)
 

--- a/megatron/spiral/optimizer/stage_optimizer.py
+++ b/megatron/spiral/optimizer/stage_optimizer.py
@@ -9,8 +9,12 @@ class SpiralStageOptimizer:
 
     def __init__(self, optimizers, *args, **kwargs):
         self.optimizer_list = optimizers  # do not change attr name
-        self.grad_scaler = self.optimizer_list[0].grad_scaler if len(self.optimizer_list) > 0 else None
+
+        self.grad_scaler = None
+        if len(self.optimizer_list) > 0 and hasattr(self.optimizer_list[0], 'grad_scaler'):
+            self.grad_scaler = self.optimizer_list[0].grad_scaler
         self.inv_scale_val = self.grad_scaler.inv_scale.item() if self.grad_scaler != None else 0.0
+        self.default_scale = torch.cuda.FloatTensor([1.0])
 
     # Required for checkpointing
     def state_dict(self):
@@ -45,7 +49,10 @@ class SpiralStageOptimizer:
     param_groups = property(_get_param_groups)
 
     def get_loss_scale(self):
-        return self.grad_scaler.scale
+        if self.grad_scaler:
+            return self.grad_scaler.scale
+        else:
+            return self.default_scale
     
     def scale_loss(self, loss):
         """Simple scaling."""


### PR DESCRIPTION
### Feature
With Mixed Precision, inf/nan may occur when unscaling the gradient.
If inf/nan occurs, the entire updated parameter should be rollback for training accuracy.
In model parallel all_reduce is needed to get inf/nan from other ranks.
The staged optimizer execute the thread optimizer regardless of whether inf/nan occurs or not, and runs the rollback logic after checking whether inf/nan occurs at optimizer sync (flush).

Reference: Zero Bubble (Almost) Pipeline Parallelism [paper](https://openreview.net/pdf?id=tuzTN0eIO5)

### csrc 수정사항
- rollback 로직 추가
- 사용하지 않는 `adam_update_copy` 함수, `dev_params`, `half_precision` argument 삭제
- dev_params 복사 처리를 위한 cuda stream 관련 코드 삭제
- simd 연산 추가를 위해 simd.hpp 파일 추가 (from deepspeed)