### PR TITLE
Implement first stage gpu optimizer

### DIFF
--- a/examples/asplos25/config.sh
+++ b/examples/asplos25/config.sh
@@ -80,8 +80,12 @@ SPIRAL_SHMEM_BUFFER_SIZE=${SHMEM_BUFFER_SIZE:=$(( 64 * 2**30 ))}
 SPIRAL_SHMEM_HEADER_SIZE=$(( 1 * 2**30 ))
 SPIRAL_DEBUG_BACKEND=NO
 
-if [[ "$OPTIMIZER" == "stage" ]]; then
+SPIRAL_HETERO_OPTIMIZER=NO
+if [[ "$OPTIMIZER" == *"stage"* ]]; then
     SPIRAL_STAGE_OPTIMIZER=YES
+    if [[ "$OPTIMIZER" == *"hetero"* ]]; then
+        SPIRAL_HETERO_OPTIMIZER=YES
+    fi
 else
     SPIRAL_STAGE_OPTIMIZER=NO
 fi

--- a/examples/asplos25/extra_args/mobius.sh
+++ b/examples/asplos25/extra_args/mobius.sh
@@ -20,3 +20,7 @@ if [ ${SPIRAL_STAGE_OPTIMIZER} == "YES" ]; then
     --spiral-stage-optimizer-pool-size 0
     "
 fi
+
+if [ ${SPIRAL_HETERO_OPTIMIZER} == "YES" ]; then
+    EXTRA_ARGS+=" --spiral-heterogeneous-optimizer"
+fi

--- a/examples/asplos25/extra_args/spiral.sh
+++ b/examples/asplos25/extra_args/spiral.sh
@@ -25,6 +25,10 @@ if [ ${SPIRAL_STAGE_OPTIMIZER} == "YES" ]; then
     "
 fi
 
+if [ ${SPIRAL_HETERO_OPTIMIZER} == "YES" ]; then
+    EXTRA_ARGS+=" --spiral-heterogeneous-optimizer"
+fi
+
 if [ ${SPIRAL_CROSS_MAPPING} == "YES" ]; then
     EXTRA_ARGS+=" --spiral-cross-mapping"
 fi

--- a/examples/asplos25/run.sh
+++ b/examples/asplos25/run.sh
@@ -47,6 +47,6 @@ if [ ${NSYS_ENABLE} == "YES" ]; then
 fi
 
 # Run script
-${MPIRUN} -npernode $GPUS_PER_NODE -host $HOSTS $MPI_OPTIONS ${EXEC_CMD}
+${MPIRUN} --bind-to none --report-bindings -npernode $GPUS_PER_NODE -host $HOSTS $MPI_OPTIONS ${EXEC_CMD}
 
 exit 0

--- a/megatron/arguments.py
+++ b/megatron/arguments.py
@@ -439,6 +439,9 @@ def validate_args(args, defaults={}):
         if args.use_distributed_optimizer:
             raise RuntimeError(
                 "SpiralPipe currently does not support distributed optimizer")
+        if args.spiral_heterogeneous_optimizer:
+            assert args.spiral_stage_optimizer, "spiral-stage-optimizer should be enabled with spiral-heterogeneous-optimizer"
+        
 
     # GQA
     if args.num_key_value_heads is None:
@@ -1111,6 +1114,9 @@ def _add_distributed_args(parser):
     group.add_argument('--spiral-stage-optimizer-pool-size', type=int, default=0,
                         help='Thread pool size per spiral stage optimizer when --spiral-stage-optimizer is enabled'
                         'Default value (0) enables dynamic thread pool sizing')
+    group.add_argument('--spiral-heterogeneous-optimizer', action='store_true',
+                        help='Enable cpu-gpu heterogeneous optimizer per each stage. '
+                        'Use gpu optimizer for the first stage and cpu optimizer for the others')
     group.add_argument('--spiral-debug-backend', action='store_true',
                        help='Enable SpiralPipe backend logging')
     group.add_argument('--spiral-cross-mapping', action='store_true',

--- a/megatron/arguments.py
+++ b/megatron/arguments.py
@@ -440,7 +440,7 @@ def validate_args(args, defaults={}):
             raise RuntimeError(
                 "SpiralPipe currently does not support distributed optimizer")
         if args.spiral_heterogeneous_optimizer:
-            assert args.spiral_stage_optimizer, "spiral-stage-optimizer should be enabled with spiral-heterogeneous-optimizer"
+            assert args.spiral_stage_optimizer, "spiral-heterogeneous-optimizer should be enabled with spiral-stage-optimizer"
         
 
     # GQA

--- a/megatron/optimizer/__init__.py
+++ b/megatron/optimizer/__init__.py
@@ -157,6 +157,9 @@ def get_megatron_optimizer(model,
             else:
                 from megatron.spiral.optimizer.cpu_adam import SpiralCPUAdam
                 inner_opt_ty = SpiralCPUAdam
+                # NOTE (SpiralPipe) `params` here annotates the "optimizer params". It is not always the same as the params referenced during training.
+                # For SpiralPipe, the optimizer params are the offloaded params and hence should only have grad field, while the params referred during can have both main_grad and grad field.
+                # Hence, setting `params_have_main_grad` to True incurs explicit copy from main_grad into grad (optimizer.step() calls it), which is not necessary.
                 params_have_main_grad = False
         else:
             from deepspeed.ops.adam import DeepSpeedCPUAdam

--- a/megatron/optimizer/__init__.py
+++ b/megatron/optimizer/__init__.py
@@ -48,7 +48,8 @@ def get_param_groups(modules,
             if not param.requires_grad:
                 continue
 
-            if args.spiral:
+            # TODO: This is for DeepSpeedCPUOptimizer which will be deprecated.
+            if args.spiral and not args.spiral_stage_optimizer:
                 # Only params converted to spiral param and currently placed on local CPU memory should enter,
                 # as it is the necessary condition for backward stages
                 assert (is_spiral_param(param))
@@ -62,7 +63,8 @@ def get_param_groups(modules,
                 no_wd = no_weight_decay_cond(name, param)
             else:
                 # do not regularize biases nor Norm parameters
-                no_wd = name.endswith(".bias") or len(param.shape) == 1
+                shape = param.spiral_shape if args.spiral else param.shape
+                no_wd = name.endswith(".bias") or len(shape) == 1
 
             if scale_lr_cond is not None:
                 if args.spiral:

--- a/megatron/optimizer/__init__.py
+++ b/megatron/optimizer/__init__.py
@@ -63,7 +63,7 @@ def get_param_groups(modules,
                 no_wd = no_weight_decay_cond(name, param)
             else:
                 # do not regularize biases nor Norm parameters
-                shape = param.spiral_shape if args.spiral else param.shape
+                shape = param.spiral_shape if args.spiral and args.spiral_stage_optimizer else param.shape
                 no_wd = name.endswith(".bias") or len(shape) == 1
 
             if scale_lr_cond is not None:
@@ -156,7 +156,8 @@ def get_megatron_optimizer(model,
             # NOTE (SpiralPipe) Spiral stage optimizer uses SpiralCPUAdam, which overlaps weight update with upstream bwd stage computation.
             # If --spiral-heterogeneous-optimizer is enabled, apply gpu optimizer to first stage.
             if args.spiral_heterogeneous_optimizer and _unwrapped_model.spiral_backward_stage_id == 0:
-                inner_opt_ty = Adam
+                from megatron.spiral.optimizer.gpu_adam import SpiralGPUAdam
+                inner_opt_ty = SpiralGPUAdam
             else:
                 from megatron.spiral.optimizer.cpu_adam import SpiralCPUAdam
                 inner_opt_ty = SpiralCPUAdam

--- a/megatron/optimizer/__init__.py
+++ b/megatron/optimizer/__init__.py
@@ -13,7 +13,7 @@ from .distrib_optimizer import DistributedOptimizer
 from .grad_scaler import ConstantGradScaler, DynamicGradScaler
 from .optimizer import Float16OptimizerWithFloat16Params, FP32Optimizer
 from megatron.spiral.optimizer.stage_optimizer import SpiralStageOptimizer
-from megatron.spiral.optimizer.optimizer import SpiralFloat16Optimizer, SpiralFP32Optimizer
+from megatron.spiral.optimizer.optimizer import SpiralFloat16Optimizer, DeepSpeedFloat16Optimizer, SpiralFP32Optimizer
 
 
 def get_param_groups(modules,
@@ -102,12 +102,8 @@ def get_megatron_optimizer(model,
 
     # Determine whether the params have main-grad field.
     params_have_main_grad = False
-    if args.spiral:
-        # NOTE (SpiralPipe) `params` here annotates the "optimizer params". It is not always the same as the params referenced during training. For SpiralPipe, the optimizer params are the offloaded params and hence should only have grad field, while the params referred during can have both main_grad and grad field. Hence, setting `params_have_main_grad` to True incurs explicit copy from main_grad into grad (optimizer.step() calls it), which is not necessary.
-        params_have_main_grad = False
-    else:
-        if args.DDP_impl == 'local':
-            params_have_main_grad = True
+    if args.DDP_impl == 'local':
+        params_have_main_grad = True
 
     if (
         args.spiral
@@ -161,9 +157,11 @@ def get_megatron_optimizer(model,
             else:
                 from megatron.spiral.optimizer.cpu_adam import SpiralCPUAdam
                 inner_opt_ty = SpiralCPUAdam
+                params_have_main_grad = False
         else:
             from deepspeed.ops.adam import DeepSpeedCPUAdam
             inner_opt_ty = DeepSpeedCPUAdam
+            params_have_main_grad = False
 
         optimizer = inner_opt_ty(
             param_groups,
@@ -221,6 +219,8 @@ def get_megatron_optimizer(model,
             opt_ty = DistributedOptimizer
         elif args.spiral:
             opt_ty = SpiralFloat16Optimizer
+            if not args.spiral_stage_optimizer:
+                opt_ty = DeepSpeedFloat16Optimizer
         else:
             opt_ty = Float16OptimizerWithFloat16Params
         
@@ -236,7 +236,7 @@ def get_megatron_optimizer(model,
                     model)
 
     # FP32.
-    opt_ty = SpiralFP32Optimizer if args.spiral else FP32Optimizer
+    opt_ty = SpiralFP32Optimizer if args.spiral and args.spiral_stage_optimizer else FP32Optimizer
     return opt_ty(optimizer, args.clip_grad,
                          args.log_num_zeros_in_grad,
                          params_have_main_grad,

--- a/megatron/optimizer/__init__.py
+++ b/megatron/optimizer/__init__.py
@@ -148,10 +148,18 @@ def get_megatron_optimizer(model,
     if args.spiral:
         assert args.optimizer == 'adam', 'SpiralPipe only support Adam'
 
-        # NOTE (SpiralPipe) Spiral stage optimizer uses SpiralCPUAdam, which overlaps weight update with upstream bwd stage computation.
         if args.spiral_stage_optimizer:
-            from megatron.spiral.optimizer.cpu_adam import SpiralCPUAdam
-            inner_opt_ty = SpiralCPUAdam
+            _unwrapped_model = model[0]
+            assert hasattr(_unwrapped_model, "_spiral_optimizer_entered")
+            delattr(_unwrapped_model, "_spiral_optimizer_entered")
+
+            # NOTE (SpiralPipe) Spiral stage optimizer uses SpiralCPUAdam, which overlaps weight update with upstream bwd stage computation.
+            # If --spiral-heterogeneous-optimizer is enabled, apply gpu optimizer to first stage.
+            if args.spiral_heterogeneous_optimizer and _unwrapped_model.spiral_backward_stage_id == 0:
+                inner_opt_ty = Adam
+            else:
+                from megatron.spiral.optimizer.cpu_adam import SpiralCPUAdam
+                inner_opt_ty = SpiralCPUAdam
         else:
             from deepspeed.ops.adam import DeepSpeedCPUAdam
             inner_opt_ty = DeepSpeedCPUAdam
@@ -163,11 +171,6 @@ def get_megatron_optimizer(model,
             betas=(args.adam_beta1, args.adam_beta2),
             eps=args.adam_eps,
         )
-
-        if args.spiral_stage_optimizer:
-            _unwrapped_model = model[0]
-            assert hasattr(_unwrapped_model, "_spiral_optimizer_entered")
-            delattr(_unwrapped_model, "_spiral_optimizer_entered")
     else:
         if args.optimizer == 'adam':
             optimizer = Adam(param_groups,

--- a/megatron/optimizer/optimizer.py
+++ b/megatron/optimizer/optimizer.py
@@ -345,6 +345,7 @@ class MixedPrecisionOptimizer(MegatronOptimizer):
         self.bf16 = bf16
         self.params_dtype = params_dtype
         self.grad_scaler = grad_scaler
+        self.use_global_grad_scaler = False
 
         # None grad scaler is only supported for bf16.
         if self.grad_scaler is None:
@@ -424,8 +425,9 @@ class MixedPrecisionOptimizer(MegatronOptimizer):
 
             # We are done with scaling gradients
             # so we can update the loss scale.
-            # TODO: need to rollback this comment
-            # self.grad_scaler.update(found_inf_flag)
+            # TODO: Remove this condition and self.use_global_grad_scaler (dummy flag)
+            if not self.use_global_grad_scaler:
+                self.grad_scaler.update(found_inf_flag)
 
             # If we found inf/nan, skip the update.
             if found_inf_flag:

--- a/megatron/optimizer/optimizer.py
+++ b/megatron/optimizer/optimizer.py
@@ -424,7 +424,8 @@ class MixedPrecisionOptimizer(MegatronOptimizer):
 
             # We are done with scaling gradients
             # so we can update the loss scale.
-            self.grad_scaler.update(found_inf_flag)
+            # TODO: need to rollback this comment
+            # self.grad_scaler.update(found_inf_flag)
 
             # If we found inf/nan, skip the update.
             if found_inf_flag:

--- a/megatron/spiral/init_context.py
+++ b/megatron/spiral/init_context.py
@@ -469,11 +469,13 @@ class SpiralInitContext(InsertPostInitMethodToModuleSubClasses):
             if params_have_main_grad:
                 assert hasattr(param, "main_grad")
                 # Ensure the tensor memory is not reused for another tensor until all work queued on stream is complete
-                param.main_grad.record_stream(get_thunder_cuda_manager().Stream('offload'))
+                if param.main_grad is not None:
+                    param.main_grad.record_stream(get_thunder_cuda_manager().Stream('offload'))
                 param.main_grad = None
             if hasattr(param, "grad"):
                 # Ensure the tensor memory is not reused for another tensor until all work queued on stream is complete
-                param.grad.record_stream(get_thunder_cuda_manager().Stream('offload'))
+                if param.grad is not None:
+                    param.grad.record_stream(get_thunder_cuda_manager().Stream('offload'))
                 param.grad = None
 
         def _assert_free_grad(param: Parameter) -> None:

--- a/megatron/spiral/init_context.py
+++ b/megatron/spiral/init_context.py
@@ -372,7 +372,8 @@ class SpiralInitContext(InsertPostInitMethodToModuleSubClasses):
                 param.spiral_tensor.copy_(param.data, non_blocking=non_blocking)
 
         def _fetch_data(param, non_blocking=False):
-            # if parameter is already in gpu memory, skip fetch
+            # If parameter is already in gpu memory, skip fetch.
+            # NOTE: Most cases should naturally fetch from CPU in spiral case.
             if param.spiral_status == SpiralParamStatus.GPU:
                 return
 

--- a/megatron/spiral/init_context.py
+++ b/megatron/spiral/init_context.py
@@ -370,12 +370,12 @@ class SpiralInitContext(InsertPostInitMethodToModuleSubClasses):
                     param.spiral_tensor.shape == param.data.shape
                 ), f"Offload tensor shape mismatch ({param.spiral_tensor.shape} != {param.data.shape})"
                 param.spiral_tensor.copy_(param.data, non_blocking=non_blocking)
-            if not non_blocking:
-                # NOTE: for non-blocking offload, spiral_status should be changed after waiting in the caller
-                param.spiral_status = SpiralParamStatus.CPU
 
         def _fetch_data(param, non_blocking=False):
-            assert param.spiral_status == SpiralParamStatus.CPU
+            # if parameter is already in gpu memory, skip fetch
+            if param.spiral_status == SpiralParamStatus.GPU:
+                return
+
             assert param.spiral_tensor is not None, "Fetch tensor is None"
 
             if param.numel() == 0:

--- a/megatron/spiral/optimizer/cpu_adam.py
+++ b/megatron/spiral/optimizer/cpu_adam.py
@@ -7,6 +7,9 @@ from deepspeed.utils.logging import should_log_le
 
 from .cpu_adam_builder import SpiralCPUAdamBuilder
 
+from megatron.spiral.init_context import SpiralParamStatus
+from megatron.spiral.utils import is_spiral_param
+
 class SpiralCPUAdam(torch.optim.Optimizer):
     optimizer_id = 0
 
@@ -74,6 +77,15 @@ class SpiralCPUAdam(torch.optim.Optimizer):
             bias_correction=bias_correction,
             amsgrad=amsgrad,
         )
+
+        # set spiral_tensor as param_groups
+        for group in model_params:
+            for param_id, p in enumerate(group["params"]):
+                assert (is_spiral_param(p))
+                assert (p.spiral_status == SpiralParamStatus.CPU)
+                assert (p.spiral_tensor.numel() == p.spiral_numel)
+                group["params"][param_id] = p.spiral_tensor
+
         super(SpiralCPUAdam, self).__init__(model_params, default_args)
 
         cpu_info = get_cpu_info()

--- a/megatron/spiral/optimizer/cpu_adam.py
+++ b/megatron/spiral/optimizer/cpu_adam.py
@@ -304,9 +304,3 @@ class SpiralCPUAdam(torch.optim.Optimizer):
             found_inf = torch.FloatTensor([0])
         self.ds_opt_adam.adam_sync(self.opt_id, found_inf)
         self.optimizer_locked = False
-
-    def set_inv_scale(self, inv_scale):
-        self.inv_scale = inv_scale
-
-    def set_event_long(self, ev_long):
-        self.ev_long = ev_long

--- a/megatron/spiral/optimizer/gpu_adam.py
+++ b/megatron/spiral/optimizer/gpu_adam.py
@@ -1,0 +1,305 @@
+import torch
+from apex.multi_tensor_apply import multi_tensor_applier
+
+class FusedAdam(torch.optim.Optimizer):
+
+    """Implements Adam algorithm.
+
+    Currently GPU-only.  Requires Apex to be installed via
+    ``pip install -v --no-cache-dir --global-option="--cpp_ext" --global-option="--cuda_ext" ./``.
+
+    This version of fused Adam implements 2 fusions.
+
+      * Fusion of the Adam update's elementwise operations
+      * A multi-tensor apply launch that batches the elementwise updates applied to all the model's parameters into one or a few kernel launches.
+
+    :class:`apex.optimizers.FusedAdam` may be used as a drop-in replacement for ``torch.optim.AdamW``,
+    or ``torch.optim.Adam`` with ``adam_w_mode=False``::
+
+        opt = apex.optimizers.FusedAdam(model.parameters(), lr = ....)
+        ...
+        opt.step()
+
+    :class:`apex.optimizers.FusedAdam` may be used with or without Amp.  If you wish to use :class:`FusedAdam` with Amp,
+    you may choose any ``opt_level``::
+
+        opt = apex.optimizers.FusedAdam(model.parameters(), lr = ....)
+        model, opt = amp.initialize(model, opt, opt_level="O0" or "O1 or "O2")
+        ...
+        opt.step()
+
+    In general, ``opt_level="O1"`` is recommended.
+
+
+    .. warning::
+        A previous version of :class:`FusedAdam` allowed a number of additional arguments to ``step``.  These additional arguments
+        are now deprecated and unnecessary.
+
+    Adam was been proposed in `Adam: A Method for Stochastic Optimization`_.
+
+    Arguments:
+        params (iterable): iterable of parameters to optimize or dicts defining
+            parameter groups.
+        lr (float, optional): learning rate. (default: 1e-3)
+        betas (Tuple[float, float], optional): coefficients used for computing
+            running averages of gradient and its square. (default: (0.9, 0.999))
+        eps (float, optional): term added to the denominator to improve
+            numerical stability. (default: 1e-8)
+        weight_decay (float, optional): weight decay (L2 penalty) (default: 0)
+        amsgrad (boolean, optional): whether to use the AMSGrad variant of this
+            algorithm from the paper `On the Convergence of Adam and Beyond`_
+            (default: False) NOT SUPPORTED in FusedAdam!
+        adam_w_mode (boolean, optional): Apply L2 regularization or weight decay
+            True for decoupled weight decay(also known as AdamW) (default: True)
+        set_grad_none (bool, optional): whether set grad to None when zero_grad()
+            method is called. (default: True)
+        capturable (bool, optional): whether to use the version of the optimizer
+            that can be used with CUDA Graphs. (default: False)
+        master_weights (bool, optional): whether to maintain FP32 master weights
+           in the optimizer with FP16 mixed precision training, currently can
+           only be used with capturable set to True. (default: False)
+
+    .. _Adam - A Method for Stochastic Optimization:
+        https://arxiv.org/abs/1412.6980
+    .. _On the Convergence of Adam and Beyond:
+        https://openreview.net/forum?id=ryQu7f-RZ
+    """
+
+    def __init__(self, params, lr=1e-3, bias_correction=True,
+                 betas=(0.9, 0.999), eps=1e-8, adam_w_mode=True,
+                 weight_decay=0., amsgrad=False, set_grad_none=True,
+                 capturable=False, master_weights=False):
+
+        if amsgrad:
+            raise RuntimeError('FusedAdam does not support the AMSGrad variant.')
+        if master_weights and not capturable:
+            raise RuntimeError('Master weights is currently only supported with the capturable version.')
+        # If the optimizer is capturable then LR should be a tensor (on GPU)
+        lr = torch.tensor(lr, dtype=torch.float32) if capturable else lr
+        defaults = dict(lr=lr, bias_correction=bias_correction,
+                        betas=betas, eps=eps, weight_decay=weight_decay)
+        super(FusedAdam, self).__init__(params, defaults)
+        self.adam_w_mode = 1 if adam_w_mode else 0
+        self.set_grad_none = set_grad_none
+
+        self.capturable = capturable
+        self.master_weights = master_weights
+
+        # Create full precision master weights
+        self.param_groups_master = []
+        for i, pg in enumerate(self.param_groups):
+            param_list = pg['params']
+            self.param_groups_master.append({
+                'params': [
+                    p.clone().detach().float() if self.master_weights else None
+                    for p in param_list
+                ],
+            })
+
+        if capturable:
+            for idx, group in enumerate(self.param_groups):
+                if len(group['params']) == 0:
+                    continue
+                device = group['params'][0].device
+                for item in ['lr']:
+                    self.param_groups[idx][item] = group[item].to(device=device)
+
+            self._step_supports_amp_scaling = True
+
+        if multi_tensor_applier.available:
+            import amp_C
+            # Skip buffer
+            self._dummy_overflow_buf = torch.cuda.IntTensor([0])
+            self.multi_tensor_adam = amp_C.multi_tensor_adam
+            self.multi_tensor_adam_capturable = amp_C.multi_tensor_adam_capturable
+            self.multi_tensor_adam_capturable_master = amp_C.multi_tensor_adam_capturable_master
+        else:
+            raise RuntimeError('apex.optimizers.FusedAdam requires cuda extensions')
+
+    def zero_grad(self):
+        if self.set_grad_none:
+            for group in self.param_groups:
+                for p in group['params']:
+                    p.grad = None
+        else:
+            super(FusedAdam, self).zero_grad()
+
+    def step(self, closure=None, grads=None, output_params=None, scale=None, grad_norms=None, grad_scaler=None):
+        """Performs a single optimization step.
+
+        Arguments:
+            closure (callable, optional): A closure that reevaluates the model
+                and returns the loss.
+
+        The remaining arguments are deprecated, and are only retained (for the moment) for error-checking purposes.
+        """
+        if any(p is not None for p in [grads, output_params, scale, grad_norms]):
+            raise RuntimeError('FusedAdam has been updated.  Simply initialize it identically to torch.optim.Adam, and call step() with no arguments.')
+        loss = None
+        if closure is not None:
+            loss = closure()
+
+        for group, group_master in zip(self.param_groups, self.param_groups_master):
+            if len(group['params']) == 0:
+                continue
+            device = group['params'][0].device
+            bias_correction = 1 if group['bias_correction'] else 0
+            beta1, beta2 = group['betas']
+
+            # assume same step across group now to simplify things
+            # per parameter step can be easily support by making it tensor, or pass list into kernel
+            if 'step' in group:
+                group['step'] += 1 if not self.capturable else (self._dummy_overflow_buf != 1).to(torch.int)
+            else:
+                group['step'] = 1 if not self.capturable else torch.tensor([1], dtype=torch.int, device=device)
+
+            # create lists for multi-tensor apply
+            g_16, p_16, m_16, v_16 = [], [], [], []
+            g_bf, p_bf, m_bf, v_bf = [], [], [], []
+            g_32, p_32, m_32, v_32 = [], [], [], []
+            p_16_master = []
+            p_32_master = []
+
+            for p, p_master in zip(group['params'], group_master['params']):
+                if p.grad is None:
+                    continue
+                if p.grad.data.is_sparse:
+                    raise RuntimeError('FusedAdam does not support sparse gradients, please consider SparseAdam instead')
+
+                state = self.state[p]
+                # State initialization
+                if len(state) == 0:
+                    # Exponential moving average of gradient values
+                    state['exp_avg'] = torch.zeros_like(p.data).float()
+                    # Exponential moving average of squared gradient values
+                    state['exp_avg_sq'] = torch.zeros_like(p.data).float()
+
+                if p.dtype == torch.float16:
+                    if self.master_weights:
+                        p_16_master.append(p_master.data)
+                    g_16.append(p.grad.data)
+                    p_16.append(p.data)
+                    m_16.append(state['exp_avg'])
+                    v_16.append(state['exp_avg_sq'])
+                elif p.dtype == torch.bfloat16:
+                    g_bf.append(p.grad)
+                    p_bf.append(p)
+                    m_bf.append(state['exp_avg'])
+                    v_bf.append(state['exp_avg_sq'])
+                elif p.dtype == torch.float32:
+                    if self.master_weights:
+                        p_32_master.append(p_master.data)
+                    g_32.append(p.grad.data)
+                    p_32.append(p.data)
+                    m_32.append(state['exp_avg'])
+                    v_32.append(state['exp_avg_sq'])
+                else:
+                    raise RuntimeError('FusedAdam only support fp16 and fp32.')
+
+            # If the optimizer is capturable, then if there's a grad scaler it works
+            # on the GPU + a different multi_tensor_applier should be called
+            if self.capturable:
+                # overflow check of gradients
+                found_inf = (
+                    grad_scaler._check_inf_per_device(self)[device]
+                    if grad_scaler is not None else torch.zeros((1,), device=device)
+                )
+                self._dummy_overflow_buf.copy_(found_inf)
+
+                # get unscale scale factor
+                scale, inv_scale = None, None
+                if grad_scaler:
+                    scale = grad_scaler._get_scale_async()
+                    inv_scale = scale.double().reciprocal().float()
+                else:
+                    scale = torch.ones((1,), device=device)
+                    inv_scale = torch.ones((1,), device=device)
+
+                if len(g_16) > 0:
+                    multi_tensor_applier(self.multi_tensor_adam_capturable_master if self.master_weights
+                            else self.multi_tensor_adam_capturable,
+                            self._dummy_overflow_buf,
+                            [g_16, p_16, m_16, v_16, p_16_master] if self.master_weights
+                            else [g_16, p_16, m_16, v_16],
+                            group['lr'],
+                            beta1,
+                            beta2,
+                            group['eps'],
+                            group['step'],
+                            self.adam_w_mode,
+                            bias_correction,
+                            group['weight_decay'],
+                            inv_scale)
+
+                if len(g_bf) > 0:
+                    multi_tensor_applier(
+                            self.multi_tensor_adam_capturable,
+                            self._dummy_overflow_buf,
+                            [g_bf, p_bf, m_bf, v_bf],
+                            group['lr'],
+                            beta1,
+                            beta2,
+                            group['eps'],
+                            group['step'],
+                            self.adam_w_mode,
+                            bias_correction,
+                            group['weight_decay'],
+                            inv_scale)
+
+                if len(g_32) > 0:
+                    multi_tensor_applier(self.multi_tensor_adam_capturable_master if self.master_weights
+                            else self.multi_tensor_adam_capturable,
+                            self._dummy_overflow_buf,
+                            [g_32, p_32, m_32, v_32, p_32_master] if self.master_weights
+                            else [g_32, p_32, m_32, v_32],
+                            group['lr'],
+                            beta1,
+                            beta2,
+                            group['eps'],
+                            group['step'],
+                            self.adam_w_mode,
+                            bias_correction,
+                            group['weight_decay'],
+                            inv_scale)
+            else:
+                if len(g_16) > 0:
+                    multi_tensor_applier(self.multi_tensor_adam,
+                            self._dummy_overflow_buf,
+                            [g_16, p_16, m_16, v_16],
+                            group['lr'],
+                            beta1,
+                            beta2,
+                            group['eps'],
+                            group['step'],
+                            self.adam_w_mode,
+                            bias_correction,
+                            group['weight_decay'])
+
+                if len(g_bf) > 0:
+                    multi_tensor_applier(
+                            self.multi_tensor_adam,
+                            self._dummy_overflow_buf,
+                            [g_bf, p_bf, m_bf, v_bf],
+                            group['lr'],
+                            beta1,
+                            beta2,
+                            group['eps'],
+                            group['step'],
+                            self.adam_w_mode,
+                            bias_correction,
+                            group['weight_decay'])
+
+                if len(g_32) > 0:
+                    multi_tensor_applier(self.multi_tensor_adam,
+                            self._dummy_overflow_buf,
+                            [g_32, p_32, m_32, v_32],
+                            group['lr'],
+                            beta1,
+                            beta2,
+                            group['eps'],
+                            group['step'],
+                            self.adam_w_mode,
+                            bias_correction,
+                            group['weight_decay'])
+
+        return loss

--- a/megatron/spiral/optimizer/gpu_adam.py
+++ b/megatron/spiral/optimizer/gpu_adam.py
@@ -2,7 +2,7 @@
 #   https://github.com/NVIDIA/apex/blob/741bdf50825a97664db08574981962d66436d16a/apex/optimizers/fused_adam.py
 #   https://github.com/sail-sg/zero-bubble-pipeline-parallelism
 # with some modifications.
-   
+
 import torch
 from apex.multi_tensor_apply import multi_tensor_applier
 
@@ -40,8 +40,8 @@ class SpiralGPUAdam(torch.optim.Optimizer):
 
         if amsgrad:
             raise RuntimeError('SpiralGPUAdam does not support the AMSGrad variant.')
-        if master_weights and not capturable:
-            raise RuntimeError('Master weights is currently only supported with the capturable version.')
+        if capturable or master_weights:
+            raise RuntimeError('SpiralGPUAdam does not support catureable or master_weights.')
         # If the optimizer is capturable then LR should be a tensor (on GPU)
         lr = torch.tensor(lr, dtype=torch.float32) if capturable else lr
         defaults = dict(lr=lr, bias_correction=bias_correction,
@@ -49,30 +49,6 @@ class SpiralGPUAdam(torch.optim.Optimizer):
         super(SpiralGPUAdam, self).__init__(params, defaults)
         self.adam_w_mode = 1 if adam_w_mode else 0
         self.set_grad_none = set_grad_none
-
-        self.capturable = capturable
-        self.master_weights = master_weights
-
-        # Create full precision master weights
-        self.param_groups_master = []
-        for i, pg in enumerate(self.param_groups):
-            param_list = pg['params']
-            self.param_groups_master.append({
-                'params': [
-                    p.clone().detach().float() if self.master_weights else None
-                    for p in param_list
-                ],
-            })
-
-        if capturable:
-            for idx, group in enumerate(self.param_groups):
-                if len(group['params']) == 0:
-                    continue
-                device = group['params'][0].device
-                for item in ['lr']:
-                    self.param_groups[idx][item] = group[item].to(device=device)
-
-            self._step_supports_amp_scaling = True
 
         if multi_tensor_applier.available:
             import amp_C
@@ -107,7 +83,7 @@ class SpiralGPUAdam(torch.optim.Optimizer):
         if closure is not None:
             loss = closure()
 
-        for group, group_master in zip(self.param_groups, self.param_groups_master):
+        for group in self.param_groups:
             if len(group['params']) == 0:
                 continue
             device = group['params'][0].device
@@ -117,18 +93,16 @@ class SpiralGPUAdam(torch.optim.Optimizer):
             # assume same step across group now to simplify things
             # per parameter step can be easily support by making it tensor, or pass list into kernel
             if 'step' in group:
-                group['step'] += 1 if not self.capturable else (self._dummy_overflow_buf != 1).to(torch.int)
+                group['step'] += 1
             else:
-                group['step'] = 1 if not self.capturable else torch.tensor([1], dtype=torch.int, device=device)
+                group['step'] = 1
 
             # create lists for multi-tensor apply
             g_16, p_16, m_16, v_16 = [], [], [], []
             g_bf, p_bf, m_bf, v_bf = [], [], [], []
             g_32, p_32, m_32, v_32 = [], [], [], []
-            p_16_master = []
-            p_32_master = []
 
-            for p, p_master in zip(group['params'], group_master['params']):
+            for p in group['params']:
                 if p.grad is None:
                     continue
                 if p.grad.data.is_sparse:
@@ -143,8 +117,6 @@ class SpiralGPUAdam(torch.optim.Optimizer):
                     state['exp_avg_sq'] = torch.zeros_like(p.data).float()
 
                 if p.dtype == torch.float16:
-                    if self.master_weights:
-                        p_16_master.append(p_master.data)
                     g_16.append(p.grad.data)
                     p_16.append(p.data)
                     m_16.append(state['exp_avg'])
@@ -155,8 +127,6 @@ class SpiralGPUAdam(torch.optim.Optimizer):
                     m_bf.append(state['exp_avg'])
                     v_bf.append(state['exp_avg_sq'])
                 elif p.dtype == torch.float32:
-                    if self.master_weights:
-                        p_32_master.append(p_master.data)
                     g_32.append(p.grad.data)
                     p_32.append(p.data)
                     m_32.append(state['exp_avg'])
@@ -164,122 +134,54 @@ class SpiralGPUAdam(torch.optim.Optimizer):
                 else:
                     raise RuntimeError('SpiralGPUAdam only support fp16 and fp32.')
 
-            # If the optimizer is capturable, then if there's a grad scaler it works
-            # on the GPU + a different multi_tensor_applier should be called
-            if self.capturable:
-                # overflow check of gradients
-                found_inf = (
-                    grad_scaler._check_inf_per_device(self)[device]
-                    if grad_scaler is not None else torch.zeros((1,), device=device)
-                )
-                self._dummy_overflow_buf.copy_(found_inf)
+            if len(g_16) > 0:
+                multi_tensor_applier(self.multi_tensor_adam,
+                        self._dummy_overflow_buf,
+                        [g_16, p_16, m_16, v_16],
+                        group['lr'],
+                        beta1,
+                        beta2,
+                        group['eps'],
+                        group['step'],
+                        self.adam_w_mode,
+                        bias_correction,
+                        group['weight_decay'])
 
-                # get unscale scale factor
-                scale, inv_scale = None, None
-                if grad_scaler:
-                    scale = grad_scaler._get_scale_async()
-                    inv_scale = scale.double().reciprocal().float()
-                else:
-                    scale = torch.ones((1,), device=device)
-                    inv_scale = torch.ones((1,), device=device)
+            if len(g_bf) > 0:
+                multi_tensor_applier(
+                        self.multi_tensor_adam,
+                        self._dummy_overflow_buf,
+                        [g_bf, p_bf, m_bf, v_bf],
+                        group['lr'],
+                        beta1,
+                        beta2,
+                        group['eps'],
+                        group['step'],
+                        self.adam_w_mode,
+                        bias_correction,
+                        group['weight_decay'])
 
-                if len(g_16) > 0:
-                    multi_tensor_applier(self.multi_tensor_adam_capturable_master if self.master_weights
-                            else self.multi_tensor_adam_capturable,
-                            self._dummy_overflow_buf,
-                            [g_16, p_16, m_16, v_16, p_16_master] if self.master_weights
-                            else [g_16, p_16, m_16, v_16],
-                            group['lr'],
-                            beta1,
-                            beta2,
-                            group['eps'],
-                            group['step'],
-                            self.adam_w_mode,
-                            bias_correction,
-                            group['weight_decay'],
-                            inv_scale)
-
-                if len(g_bf) > 0:
-                    multi_tensor_applier(
-                            self.multi_tensor_adam_capturable,
-                            self._dummy_overflow_buf,
-                            [g_bf, p_bf, m_bf, v_bf],
-                            group['lr'],
-                            beta1,
-                            beta2,
-                            group['eps'],
-                            group['step'],
-                            self.adam_w_mode,
-                            bias_correction,
-                            group['weight_decay'],
-                            inv_scale)
-
-                if len(g_32) > 0:
-                    multi_tensor_applier(self.multi_tensor_adam_capturable_master if self.master_weights
-                            else self.multi_tensor_adam_capturable,
-                            self._dummy_overflow_buf,
-                            [g_32, p_32, m_32, v_32, p_32_master] if self.master_weights
-                            else [g_32, p_32, m_32, v_32],
-                            group['lr'],
-                            beta1,
-                            beta2,
-                            group['eps'],
-                            group['step'],
-                            self.adam_w_mode,
-                            bias_correction,
-                            group['weight_decay'],
-                            inv_scale)
-            else:
-                if len(g_16) > 0:
-                    multi_tensor_applier(self.multi_tensor_adam,
-                            self._dummy_overflow_buf,
-                            [g_16, p_16, m_16, v_16],
-                            group['lr'],
-                            beta1,
-                            beta2,
-                            group['eps'],
-                            group['step'],
-                            self.adam_w_mode,
-                            bias_correction,
-                            group['weight_decay'])
-
-                if len(g_bf) > 0:
-                    multi_tensor_applier(
-                            self.multi_tensor_adam,
-                            self._dummy_overflow_buf,
-                            [g_bf, p_bf, m_bf, v_bf],
-                            group['lr'],
-                            beta1,
-                            beta2,
-                            group['eps'],
-                            group['step'],
-                            self.adam_w_mode,
-                            bias_correction,
-                            group['weight_decay'])
-
-                if len(g_32) > 0:
-                    multi_tensor_applier(self.multi_tensor_adam,
-                            self._dummy_overflow_buf,
-                            [g_32, p_32, m_32, v_32],
-                            group['lr'],
-                            beta1,
-                            beta2,
-                            group['eps'],
-                            group['step'],
-                            self.adam_w_mode,
-                            bias_correction,
-                            group['weight_decay'])
+            if len(g_32) > 0:
+                multi_tensor_applier(self.multi_tensor_adam,
+                        self._dummy_overflow_buf,
+                        [g_32, p_32, m_32, v_32],
+                        group['lr'],
+                        beta1,
+                        beta2,
+                        group['eps'],
+                        group['step'],
+                        self.adam_w_mode,
+                        bias_correction,
+                        group['weight_decay'])
 
         return loss
 
     def rollback(self):
-        if self.capturable:
-            raise ValueError("Not supported")
         if not self.adam_w_mode:
-            raise ValueError("Not supported")
+            raise RuntimeError("SpiralGPUAdam only supports rollback for adam_w_mode.")
         loss = None
 
-        for group, group_master in zip(self.param_groups, self.param_groups_master):
+        for group in self.param_groups:
             if len(group['params']) == 0:
                 continue
 
@@ -290,10 +192,8 @@ class SpiralGPUAdam(torch.optim.Optimizer):
             g_16, p_16, m_16, v_16 = [], [], [], []
             g_bf, p_bf, m_bf, v_bf = [], [], [], []
             g_32, p_32, m_32, v_32 = [], [], [], []
-            p_16_master = []
-            p_32_master = []
 
-            for p, p_master in zip(group['params'], group_master['params']):
+            for p in group['params']:
                 if p.grad is None:
                     continue
                 if p.grad.data.is_sparse:
@@ -303,8 +203,6 @@ class SpiralGPUAdam(torch.optim.Optimizer):
                 assert len(state) != 0, "Rollback should be call after run optimizer.step"
 
                 if p.dtype == torch.float16:
-                    if self.master_weights:
-                        p_16_master.append(p_master.data)
                     g_16.append(p.grad.data)
                     p_16.append(p.data)
                     m_16.append(state['exp_avg'])
@@ -315,8 +213,6 @@ class SpiralGPUAdam(torch.optim.Optimizer):
                     m_bf.append(state['exp_avg'])
                     v_bf.append(state['exp_avg_sq'])
                 elif p.dtype == torch.float32:
-                    if self.master_weights:
-                        p_32_master.append(p_master.data)
                     g_32.append(p.grad.data)
                     p_32.append(p.data)
                     m_32.append(state['exp_avg'])

--- a/megatron/spiral/optimizer/gpu_adam.py
+++ b/megatron/spiral/optimizer/gpu_adam.py
@@ -1,41 +1,14 @@
+# Most of the code here has been copied from:
+#   https://github.com/NVIDIA/apex/blob/741bdf50825a97664db08574981962d66436d16a/apex/optimizers/fused_adam.py
+#   https://github.com/sail-sg/zero-bubble-pipeline-parallelism
+# with some modifications.
+   
 import torch
 from apex.multi_tensor_apply import multi_tensor_applier
 
-class FusedAdam(torch.optim.Optimizer):
+class SpiralGPUAdam(torch.optim.Optimizer):
 
     """Implements Adam algorithm.
-
-    Currently GPU-only.  Requires Apex to be installed via
-    ``pip install -v --no-cache-dir --global-option="--cpp_ext" --global-option="--cuda_ext" ./``.
-
-    This version of fused Adam implements 2 fusions.
-
-      * Fusion of the Adam update's elementwise operations
-      * A multi-tensor apply launch that batches the elementwise updates applied to all the model's parameters into one or a few kernel launches.
-
-    :class:`apex.optimizers.FusedAdam` may be used as a drop-in replacement for ``torch.optim.AdamW``,
-    or ``torch.optim.Adam`` with ``adam_w_mode=False``::
-
-        opt = apex.optimizers.FusedAdam(model.parameters(), lr = ....)
-        ...
-        opt.step()
-
-    :class:`apex.optimizers.FusedAdam` may be used with or without Amp.  If you wish to use :class:`FusedAdam` with Amp,
-    you may choose any ``opt_level``::
-
-        opt = apex.optimizers.FusedAdam(model.parameters(), lr = ....)
-        model, opt = amp.initialize(model, opt, opt_level="O0" or "O1 or "O2")
-        ...
-        opt.step()
-
-    In general, ``opt_level="O1"`` is recommended.
-
-
-    .. warning::
-        A previous version of :class:`FusedAdam` allowed a number of additional arguments to ``step``.  These additional arguments
-        are now deprecated and unnecessary.
-
-    Adam was been proposed in `Adam: A Method for Stochastic Optimization`_.
 
     Arguments:
         params (iterable): iterable of parameters to optimize or dicts defining
@@ -58,11 +31,6 @@ class FusedAdam(torch.optim.Optimizer):
         master_weights (bool, optional): whether to maintain FP32 master weights
            in the optimizer with FP16 mixed precision training, currently can
            only be used with capturable set to True. (default: False)
-
-    .. _Adam - A Method for Stochastic Optimization:
-        https://arxiv.org/abs/1412.6980
-    .. _On the Convergence of Adam and Beyond:
-        https://openreview.net/forum?id=ryQu7f-RZ
     """
 
     def __init__(self, params, lr=1e-3, bias_correction=True,
@@ -71,14 +39,14 @@ class FusedAdam(torch.optim.Optimizer):
                  capturable=False, master_weights=False):
 
         if amsgrad:
-            raise RuntimeError('FusedAdam does not support the AMSGrad variant.')
+            raise RuntimeError('SpiralGPUAdam does not support the AMSGrad variant.')
         if master_weights and not capturable:
             raise RuntimeError('Master weights is currently only supported with the capturable version.')
         # If the optimizer is capturable then LR should be a tensor (on GPU)
         lr = torch.tensor(lr, dtype=torch.float32) if capturable else lr
         defaults = dict(lr=lr, bias_correction=bias_correction,
                         betas=betas, eps=eps, weight_decay=weight_decay)
-        super(FusedAdam, self).__init__(params, defaults)
+        super(SpiralGPUAdam, self).__init__(params, defaults)
         self.adam_w_mode = 1 if adam_w_mode else 0
         self.set_grad_none = set_grad_none
 
@@ -114,7 +82,7 @@ class FusedAdam(torch.optim.Optimizer):
             self.multi_tensor_adam_capturable = amp_C.multi_tensor_adam_capturable
             self.multi_tensor_adam_capturable_master = amp_C.multi_tensor_adam_capturable_master
         else:
-            raise RuntimeError('apex.optimizers.FusedAdam requires cuda extensions')
+            raise RuntimeError('SpiralGPUAdam requires cuda extensions')
 
     def zero_grad(self):
         if self.set_grad_none:
@@ -122,7 +90,7 @@ class FusedAdam(torch.optim.Optimizer):
                 for p in group['params']:
                     p.grad = None
         else:
-            super(FusedAdam, self).zero_grad()
+            super(SpiralGPUAdam, self).zero_grad()
 
     def step(self, closure=None, grads=None, output_params=None, scale=None, grad_norms=None, grad_scaler=None):
         """Performs a single optimization step.
@@ -134,7 +102,7 @@ class FusedAdam(torch.optim.Optimizer):
         The remaining arguments are deprecated, and are only retained (for the moment) for error-checking purposes.
         """
         if any(p is not None for p in [grads, output_params, scale, grad_norms]):
-            raise RuntimeError('FusedAdam has been updated.  Simply initialize it identically to torch.optim.Adam, and call step() with no arguments.')
+            raise RuntimeError('SpiralGPUAdam has been updated.  Simply initialize it identically to torch.optim.Adam, and call step() with no arguments.')
         loss = None
         if closure is not None:
             loss = closure()
@@ -164,7 +132,7 @@ class FusedAdam(torch.optim.Optimizer):
                 if p.grad is None:
                     continue
                 if p.grad.data.is_sparse:
-                    raise RuntimeError('FusedAdam does not support sparse gradients, please consider SparseAdam instead')
+                    raise RuntimeError('SpiralGPUAdam does not support sparse gradients, please consider SparseAdam instead')
 
                 state = self.state[p]
                 # State initialization
@@ -194,7 +162,7 @@ class FusedAdam(torch.optim.Optimizer):
                     m_32.append(state['exp_avg'])
                     v_32.append(state['exp_avg_sq'])
                 else:
-                    raise RuntimeError('FusedAdam only support fp16 and fp32.')
+                    raise RuntimeError('SpiralGPUAdam only support fp16 and fp32.')
 
             # If the optimizer is capturable, then if there's a grad scaler it works
             # on the GPU + a different multi_tensor_applier should be called
@@ -303,3 +271,135 @@ class FusedAdam(torch.optim.Optimizer):
                             group['weight_decay'])
 
         return loss
+
+    def rollback(self):
+        if self.capturable:
+            raise ValueError("Not supported")
+        if not self.adam_w_mode:
+            raise ValueError("Not supported")
+        loss = None
+
+        for group, group_master in zip(self.param_groups, self.param_groups_master):
+            if len(group['params']) == 0:
+                continue
+
+            bias_correction = 1 if group['bias_correction'] else 0
+            beta1, beta2 = group['betas']
+
+            # create lists for multi-tensor apply
+            g_16, p_16, m_16, v_16 = [], [], [], []
+            g_bf, p_bf, m_bf, v_bf = [], [], [], []
+            g_32, p_32, m_32, v_32 = [], [], [], []
+            p_16_master = []
+            p_32_master = []
+
+            for p, p_master in zip(group['params'], group_master['params']):
+                if p.grad is None:
+                    continue
+                if p.grad.data.is_sparse:
+                    raise RuntimeError('SpiralGPUAdam does not support sparse gradients, please consider SparseAdam instead')
+
+                state = self.state[p]
+                assert len(state) != 0, "Rollback should be call after run optimizer.step"
+
+                if p.dtype == torch.float16:
+                    if self.master_weights:
+                        p_16_master.append(p_master.data)
+                    g_16.append(p.grad.data)
+                    p_16.append(p.data)
+                    m_16.append(state['exp_avg'])
+                    v_16.append(state['exp_avg_sq'])
+                elif p.dtype == torch.bfloat16:
+                    g_bf.append(p.grad)
+                    p_bf.append(p)
+                    m_bf.append(state['exp_avg'])
+                    v_bf.append(state['exp_avg_sq'])
+                elif p.dtype == torch.float32:
+                    if self.master_weights:
+                        p_32_master.append(p_master.data)
+                    g_32.append(p.grad.data)
+                    p_32.append(p.data)
+                    m_32.append(state['exp_avg'])
+                    v_32.append(state['exp_avg_sq'])
+                else:
+                    raise RuntimeError('SpiralGPUAdam only support fp16 and fp32.')
+
+            if len(g_16) > 0:
+                multi_tensor_rollback_adamw(
+                    g_16, p_16, m_16, v_16,
+                    group['lr'],
+                    beta1,
+                    beta2,
+                    group['eps'],
+                    group['step'],
+                    bias_correction,
+                    group['weight_decay'])
+
+            if len(g_bf) > 0:
+                multi_tensor_rollback_adamw(
+                    g_bf, p_bf, m_bf, v_bf,
+                    group['lr'],
+                    beta1,
+                    beta2,
+                    group['eps'],
+                    group['step'],
+                    bias_correction,
+                    group['weight_decay'])
+
+            if len(g_32) > 0:
+                multi_tensor_rollback_adamw(
+                    g_32, p_32, m_32, v_32,
+                    group['lr'],
+                    beta1,
+                    beta2,
+                    group['eps'],
+                    group['step'],
+                    bias_correction,
+                    group['weight_decay'])
+            group['step'] -= 1
+
+        return loss
+
+
+def multi_tensor_rollback_adamw(
+    g_list, p_list, m_list, v_list,
+    lr,
+    beta1,
+    beta2,
+    eps,
+    step,
+    bias_correction,
+    weight_decay,
+):
+    beta1_correction, beta2_correction = 1.0, 1.0
+    if bias_correction == 1:
+        beta1_correction = 1 - beta1 ** step
+        beta2_correction = 1 - beta2 ** step
+    for i, p in enumerate(p_list):
+        rollback_adamw(
+            g_list[i], p_list[i], m_list[i], v_list[i],
+            lr,
+            beta1,
+            beta2,
+            beta1_correction,
+            beta2_correction,
+            eps,
+            weight_decay,
+        )
+
+
+def rollback_adamw(
+    g: torch.Tensor, p: torch.Tensor, m: torch.Tensor, v: torch.Tensor,
+    lr,
+    beta1,
+    beta2,
+    beta1_correction,
+    beta2_correction,
+    eps,
+    decay,
+):
+    update = (m / beta1_correction) / ((v / beta2_correction).sqrt() + eps)
+    update.mul_(lr)
+    p.add_(update).div_(1 - lr * decay)
+    v.addcmul_(g, g, value=beta2 - 1).div_(beta2)
+    m.add_(g, alpha=beta1 - 1).div_(beta1)

--- a/megatron/spiral/optimizer/optimizer.py
+++ b/megatron/spiral/optimizer/optimizer.py
@@ -1,13 +1,10 @@
 import torch
 
+from megatron.core import tensor_parallel
 from megatron.optimizer.optimizer import Float16OptimizerWithFloat16Params, FP32Optimizer
 from megatron.spiral.optimizer.cpu_adam import SpiralCPUAdam
 from megatron.spiral.initialize import get_thunder_cuda_manager
 from megatron.spiral.utils import is_spiral_param
-
-
-def is_cpu_optimizer(optimizer):
-    return isinstance(optimizer, SpiralCPUAdam)
 
 
 class SpiralFloat16Optimizer(Float16OptimizerWithFloat16Params):
@@ -30,6 +27,9 @@ class SpiralFloat16Optimizer(Float16OptimizerWithFloat16Params):
                 if is_spiral_param(p):
                     p.free()
 
+        # dummy flag for temp
+        self.use_global_grad_scaler = True
+
     def _unscale_main_grads_and_check_for_nan(self):
 
         # Collect main grads.
@@ -39,6 +39,7 @@ class SpiralFloat16Optimizer(Float16OptimizerWithFloat16Params):
         self.found_inf.fill_(0.0)
 
         # Unscale and set found inf/nan
+        # TODO: need to use inv_scale of SpiralStageOptimizer
         torch._amp_foreach_non_finite_check_and_unscale_(
             main_grads, self.found_inf, self.grad_scaler.inv_scale)
 
@@ -49,10 +50,10 @@ class SpiralFloat16Optimizer(Float16OptimizerWithFloat16Params):
 
     @torch.no_grad()
     def step(self, args, timers):
-        if is_cpu_optimizer(self.optimizer):
+        if type(self.optimizer) == SpiralCPUAdam:
             return self.optimizer.step()
         else:
-            super().step(args, timers)
+            result = super().step(args, timers)
 
             for group in self.float16_groups:
                 for p in group:
@@ -65,8 +66,10 @@ class SpiralFloat16Optimizer(Float16OptimizerWithFloat16Params):
             if get_thunder_cuda_manager().record_event(self.offload_event) == -1:
                 raise RuntimeError("record_event failed")
 
+            return result
+
     def sync(self, found_inf=None):
-        if is_cpu_optimizer(self.optimizer):
+        if type(self.optimizer) == SpiralCPUAdam:
             self.optimizer.sync(found_inf)
         else:
             # TODO: check whether wait offload_event or only step_event
@@ -79,7 +82,7 @@ class SpiralFloat16Optimizer(Float16OptimizerWithFloat16Params):
 
     @torch.no_grad()
     def rollback(self, sync=False):
-        if is_cpu_optimizer(self.optimizer):
+        if type(self.optimizer) == SpiralCPUAdam:
             self.optimizer.rollback(sync)
         else:
             if self.found_inf.item() == 0:
@@ -95,10 +98,10 @@ class SpiralFloat16Optimizer(Float16OptimizerWithFloat16Params):
 class SpiralFP32Optimizer(FP32Optimizer):
     @torch.no_grad()
     def step(self, args, timers):
-        if is_cpu_optimizer(self.optimizer):
+        if type(self.optimizer) == SpiralCPUAdam:
             return self.optimizer.step()
         else:
-            super().step(args, timers)
+            result = super().step(args, timers)
 
             for group in self.optimizer.param_groups:
                 for p in group["params"]:
@@ -111,8 +114,10 @@ class SpiralFP32Optimizer(FP32Optimizer):
             if get_thunder_cuda_manager().record_event(self.offload_event) == -1:
                 raise RuntimeError("record_event failed")
 
+            return result
+
     def sync(self, found_inf=None):
-        if is_cpu_optimizer(self.optimizer):
+        if type(self.optimizer) == SpiralCPUAdam:
             self.optimizer.sync(found_inf)
         else:
             # TODO: check whether wait offload_event or only step_event
@@ -124,3 +129,92 @@ class SpiralFP32Optimizer(FP32Optimizer):
     def rollback(self, sync=False):
         # No need to rollback for fp32 param
         pass
+
+
+class DeepSpeedFloat16Optimizer(Float16OptimizerWithFloat16Params):
+    def __init__(self, optimizer, clip_grad, log_num_zeros_in_grad,
+                 params_have_main_grad, use_contiguous_buffers_in_local_ddp,
+                 fp16, bf16, params_dtype, grad_scaler, models):
+
+        super().__init__(
+            optimizer, clip_grad, log_num_zeros_in_grad,
+            params_have_main_grad, use_contiguous_buffers_in_local_ddp,
+            fp16, bf16, params_dtype, grad_scaler, models)
+
+        # Re-initialize found_inf to cpu tensor
+        if self.grad_scaler:
+            self.found_inf = torch.FloatTensor([0.0])
+
+        # Re-initialize _dummy_overflow_buf to cpu tensor
+        if not bf16:
+            self._dummy_overflow_buf = torch.IntTensor([0])
+
+        self.float16_groups = []
+        self.fp32_from_float16_groups = []
+        self.fp32_from_fp32_groups = []
+
+        # For all the groups in the original optimizer:
+        for param_group in self.optimizer.param_groups:
+            float16_params_this_group = []
+            fp32_params_this_group = []
+            fp32_from_float16_params_this_group = []
+            # For all the parameters in this group:
+            for i, param in enumerate(param_group['params']):
+                # NOTE (SpiralPipe) cpu params do not need to require grad
+
+                # float16 params:
+                if param.type() in ['torch.HalfTensor',
+                                    'torch.BFloat16Tensor']:
+                    float16_params_this_group.append(param)
+                    # Create a copy
+                    main_param = param.detach().clone().float()
+                    # Copy tensor model parallel attributes.
+                    tensor_parallel.copy_tensor_model_parallel_attributes(main_param,
+                                                                        param)
+                    if hasattr(param, 'shared'):
+                        main_param.shared = param.shared
+                    # Replace the optimizer params with the new fp32 copy.
+                    param_group['params'][i] = main_param
+
+                    fp32_from_float16_params_this_group.append(main_param)
+                    # Reset existing state dict key to the new main param.
+                    if param in self.optimizer.state:
+                        self.optimizer.state[main_param] \
+                            = self.optimizer.state.pop(param)
+                # fp32 params.
+                elif param.type() == 'torch.FloatTensor':
+                    fp32_params_this_group.append(param)
+                    param_group['params'][i] = param
+
+                else:
+                    raise TypeError('Wrapped parameters must be one of '
+                                    'torch.FloatTensor,  '
+                                    'torch.HalfTensor, or '
+                                    'torch.BFloat16Tensor. '
+                                    'Received {}'.format(param.type()))
+
+            self.float16_groups.append(float16_params_this_group)
+            self.fp32_from_float16_groups.append(
+                fp32_from_float16_params_this_group)
+            self.fp32_from_fp32_groups.append(fp32_params_this_group)
+
+    def _unscale_main_grads_and_check_for_nan(self):
+
+        # Collect main grads.
+        main_grads = self._collect_main_grad_data_for_unscaling()
+
+        # Reset found inf.
+        self.found_inf.fill_(0.0)
+
+        torch._amp_foreach_non_finite_check_and_unscale_(
+            main_grads, self.found_inf, self.grad_scaler.inv_scale.cpu())
+
+        cuda_found_inf = self.found_inf.to(device='cuda')
+        torch.distributed.all_reduce(cuda_found_inf,
+                                        op=torch.distributed.ReduceOp.MAX,
+                                        group=self.get_model_parallel_group())
+
+        # Check for nan.
+        found_inf_flag = (cuda_found_inf.item() > 0)
+
+        return found_inf_flag

--- a/megatron/spiral/optimizer/optimizer.py
+++ b/megatron/spiral/optimizer/optimizer.py
@@ -54,31 +54,18 @@ class SpiralFloat16Optimizer(Float16OptimizerWithFloat16Params):
             return self.optimizer.step()
         else:
             result = super().step(args, timers)
-
-            for group in self.float16_groups:
-                for p in group:
-                    if is_spiral_param(p):
-                        p.offload(non_blocking=True)
-                        
-            self.offload_event = get_thunder_cuda_manager().Event(
-                "offload", None, tag="offload"
-            )
-            if get_thunder_cuda_manager().record_event(self.offload_event) == -1:
-                raise RuntimeError("record_event failed")
-
+            self.step_event = torch.cuda.Event()
+            self.step_event.record()
             return result
 
     def sync(self, found_inf=None):
         if type(self.optimizer) == SpiralCPUAdam:
             self.optimizer.sync(found_inf)
         else:
-            # TODO: check whether wait offload_event or only step_event
-            if self.offload_event is not None:
-                if get_thunder_cuda_manager().wait_event(self.offload_event, sync=True) == -1:
-                    raise RuntimeError("wait_event failed")
-                self.offload_event = None
-
             found_inf.data = self.found_inf.to(device = found_inf.device, non_blocking=False)
+            if self.step_event is not None:
+                self.step_event.synchronize()
+                self.step_event = None
 
     @torch.no_grad()
     def rollback(self, sync=False):
@@ -86,6 +73,11 @@ class SpiralFloat16Optimizer(Float16OptimizerWithFloat16Params):
             self.optimizer.rollback(sync)
         else:
             if self.found_inf.item() == 0:
+                for group in self.float16_groups:
+                    for p in group:
+                        if is_spiral_param(p):
+                            p.fetch(non_blocking=not sync)
+
                 self.optimizer.rollback()
                 self._copy_main_params_to_model_params()
 
@@ -102,29 +94,17 @@ class SpiralFP32Optimizer(FP32Optimizer):
             return self.optimizer.step()
         else:
             result = super().step(args, timers)
-
-            for group in self.optimizer.param_groups:
-                for p in group["params"]:
-                    if is_spiral_param(p):
-                        p.offload(non_blocking=True)
-                        
-            self.offload_event = get_thunder_cuda_manager().Event(
-                "offload", None, tag="offload"
-            )
-            if get_thunder_cuda_manager().record_event(self.offload_event) == -1:
-                raise RuntimeError("record_event failed")
-
+            self.step_event = torch.cuda.Event()
+            self.step_event.record()
             return result
 
     def sync(self, found_inf=None):
         if type(self.optimizer) == SpiralCPUAdam:
             self.optimizer.sync(found_inf)
         else:
-            # TODO: check whether wait offload_event or only step_event
-            if self.offload_event is not None:
-                if get_thunder_cuda_manager().wait_event(self.offload_event, sync=True) == -1:
-                    raise RuntimeError("wait_event failed")
-                self.offload_event = None
+            if self.step_event is not None:
+                self.step_event.synchronize()
+                self.step_event = None
 
     def rollback(self, sync=False):
         # No need to rollback for fp32 param

--- a/megatron/spiral/optimizer/optimizer.py
+++ b/megatron/spiral/optimizer/optimizer.py
@@ -68,13 +68,13 @@ class SpiralFloat16Optimizer(Float16OptimizerWithFloat16Params):
                         p.fetch(non_blocking=False)
 
             super().step(args, timers)
-        
+
             for group in self.float16_groups:
                 for p in group:
                     if is_spiral_param(p):
                         p.offload()
                         p.free()
-                        
+
     def sync(self, found_inf=None):
         if is_cpu_optimizer(self.optimizer):
             self.optimizer.sync(found_inf)
@@ -86,8 +86,21 @@ class SpiralFloat16Optimizer(Float16OptimizerWithFloat16Params):
         if is_cpu_optimizer(self.optimizer):
             self.optimizer.rollback(sync)
         else:
-            # TODO: need to make rollback in FusedAdam
-            pass
+            if self.found_inf.item() == 0:
+                # TODO: don't need to free in schedule
+                for group in self.float16_groups:
+                    for p in group:
+                        if is_spiral_param(p):
+                            p.fetch(non_blocking=False)
+
+                self.optimizer.rollback()
+                self._copy_main_params_to_model_params()
+
+                for group in self.float16_groups:
+                    for p in group:
+                        if is_spiral_param(p):
+                            p.offload()
+                            p.free()
 
 
 class SpiralFP32Optimizer(FP32Optimizer):
@@ -104,7 +117,7 @@ class SpiralFP32Optimizer(FP32Optimizer):
                         p.fetch(non_blocking=False)
 
             super().step(args, timers)
-            
+
             for group in self.optimizer.param_groups:
                 for p in group["params"]:
                     if is_spiral_param(p):
@@ -119,8 +132,5 @@ class SpiralFP32Optimizer(FP32Optimizer):
             pass
 
     def rollback(self, sync=False):
-        if is_cpu_optimizer(self.optimizer):
-            self.optimizer.rollback(sync)
-        else:
-            # TODO: need to make rollback in FusedAdam
-            pass
+        # No need to rollback for fp32 param
+        pass

--- a/megatron/spiral/optimizer/optimizer.py
+++ b/megatron/spiral/optimizer/optimizer.py
@@ -4,6 +4,11 @@ import warnings
 from megatron.core import tensor_parallel
 from megatron.optimizer.optimizer import Float16OptimizerWithFloat16Params, FP32Optimizer
 from megatron.spiral.optimizer.cpu_adam import SpiralCPUAdam
+from megatron.spiral.utils import is_spiral_param
+
+
+def is_cpu_optimizer(optimizer):
+    return isinstance(optimizer, SpiralCPUAdam)
 
 
 class SpiralFloat16Optimizer(Float16OptimizerWithFloat16Params):
@@ -11,68 +16,20 @@ class SpiralFloat16Optimizer(Float16OptimizerWithFloat16Params):
                  params_have_main_grad, use_contiguous_buffers_in_local_ddp,
                  fp16, bf16, params_dtype, grad_scaler, models):
 
+        for group in optimizer.param_groups:
+            for p in group["params"]:
+                if is_spiral_param(p):
+                    p.fetch(non_blocking=False)
+
         super().__init__(
             optimizer, clip_grad, log_num_zeros_in_grad,
             params_have_main_grad, use_contiguous_buffers_in_local_ddp,
             fp16, bf16, params_dtype, grad_scaler, models)
-        
-        # Re-initialize found_inf to cpu tensor
-        if self.grad_scaler:
-            self.found_inf = torch.FloatTensor([0.0])
 
-        # Re-initialize _dummy_overflow_buf to cpu tensor
-        if not bf16:
-            self._dummy_overflow_buf = torch.IntTensor([0])
-        
-        self.float16_groups = []
-        self.fp32_from_float16_groups = []
-        self.fp32_from_fp32_groups = []
-
-        if type(self.optimizer) != SpiralCPUAdam:
-            # For all the groups in the original optimizer:
-            for param_group in self.optimizer.param_groups:
-                float16_params_this_group = []
-                fp32_params_this_group = []
-                fp32_from_float16_params_this_group = []
-                # For all the parameters in this group:
-                for i, param in enumerate(param_group['params']):
-                    # NOTE (SpiralPipe) cpu params do not need to require grad
-
-                    # float16 params:
-                    if param.type() in ['torch.HalfTensor',
-                                        'torch.BFloat16Tensor']:
-                        float16_params_this_group.append(param)
-                        # Create a copy
-                        main_param = param.detach().clone().float()
-                        # Copy tensor model parallel attributes.
-                        tensor_parallel.copy_tensor_model_parallel_attributes(main_param,
-                                                                            param)
-                        if hasattr(param, 'shared'):
-                            main_param.shared = param.shared
-                        # Replace the optimizer params with the new fp32 copy.
-                        param_group['params'][i] = main_param
-
-                        fp32_from_float16_params_this_group.append(main_param)
-                        # Reset existing state dict key to the new main param.
-                        if param in self.optimizer.state:
-                            self.optimizer.state[main_param] \
-                                = self.optimizer.state.pop(param)
-                    # fp32 params.
-                    elif param.type() == 'torch.FloatTensor':
-                        fp32_params_this_group.append(param)
-                        param_group['params'][i] = param
-
-                    else:
-                        raise TypeError('Wrapped parameters must be one of '
-                                        'torch.FloatTensor,  '
-                                        'torch.HalfTensor, or '
-                                        'torch.BFloat16Tensor. '
-                                        'Received {}'.format(param.type()))
-
-                self.float16_groups.append(float16_params_this_group)
-                self.fp32_from_float16_groups.append(
-                    fp32_from_float16_params_this_group)
-                self.fp32_from_fp32_groups.append(fp32_params_this_group)
+        for group in self.float16_groups:
+            for p in group:
+                if is_spiral_param(p):
+                    p.free()
 
     def _unscale_main_grads_and_check_for_nan(self):
 
@@ -84,7 +41,7 @@ class SpiralFloat16Optimizer(Float16OptimizerWithFloat16Params):
 
         # Unscale and set found inf/nan
         torch._amp_foreach_non_finite_check_and_unscale_(
-            main_grads, self.found_inf, self.grad_scaler.inv_scale.cpu())
+            main_grads, self.found_inf, self.grad_scaler.inv_scale)
 
         # Update across all model parallel instances.
         # TODO (SpiralPipe) Implement all_reduce for found_inf
@@ -100,16 +57,70 @@ class SpiralFloat16Optimizer(Float16OptimizerWithFloat16Params):
 
     @torch.no_grad()
     def step(self, args, timers):
-        if type(self.optimizer) != SpiralCPUAdam:
-            return super().step(args, timers)
-        else:
+        if is_cpu_optimizer(self.optimizer):
             return self.optimizer.step()
+        else:
+            # parameter is freed in schedule
+            # TODO: don't need to free in schedule
+            for group in self.float16_groups:
+                for p in group:
+                    if is_spiral_param(p):
+                        p.fetch(non_blocking=False)
+
+            super().step(args, timers)
+        
+            for group in self.float16_groups:
+                for p in group:
+                    if is_spiral_param(p):
+                        p.offload()
+                        p.free()
+                        
+    def sync(self, found_inf=None):
+        if is_cpu_optimizer(self.optimizer):
+            self.optimizer.sync(found_inf)
+        else:
+            # TODO: make event in step and wait until event finished
+            found_inf.data = self.found_inf.to(device = found_inf.device, non_blocking=False)
+
+    def rollback(self, sync=False):
+        if is_cpu_optimizer(self.optimizer):
+            self.optimizer.rollback(sync)
+        else:
+            # TODO: need to make rollback in FusedAdam
+            pass
 
 
 class SpiralFP32Optimizer(FP32Optimizer):
     @torch.no_grad()
     def step(self, args, timers):
-        if type(self.optimizer) != SpiralCPUAdam:
-            return super().step(args, timers)
-        else:
+        if is_cpu_optimizer(self.optimizer):
             return self.optimizer.step()
+        else:
+            # parameter is freed in schedule
+            # TODO: don't need to free in schedule
+            for group in self.optimizer.param_groups:
+                for p in group["params"]:
+                    if is_spiral_param(p):
+                        p.fetch(non_blocking=False)
+
+            super().step(args, timers)
+            
+            for group in self.optimizer.param_groups:
+                for p in group["params"]:
+                    if is_spiral_param(p):
+                        p.offload()
+                        p.free()
+
+    def sync(self, found_inf=None):
+        if is_cpu_optimizer(self.optimizer):
+            self.optimizer.sync(found_inf)
+        else:
+            # TODO: make event in step and wait until event finished
+            pass
+
+    def rollback(self, sync=False):
+        if is_cpu_optimizer(self.optimizer):
+            self.optimizer.rollback(sync)
+        else:
+            # TODO: need to make rollback in FusedAdam
+            pass

--- a/megatron/spiral/optimizer/optimizer.py
+++ b/megatron/spiral/optimizer/optimizer.py
@@ -1,9 +1,8 @@
 import torch
-import warnings
 
-from megatron.core import tensor_parallel
 from megatron.optimizer.optimizer import Float16OptimizerWithFloat16Params, FP32Optimizer
 from megatron.spiral.optimizer.cpu_adam import SpiralCPUAdam
+from megatron.spiral.initialize import get_thunder_cuda_manager
 from megatron.spiral.utils import is_spiral_param
 
 
@@ -43,13 +42,6 @@ class SpiralFloat16Optimizer(Float16OptimizerWithFloat16Params):
         torch._amp_foreach_non_finite_check_and_unscale_(
             main_grads, self.found_inf, self.grad_scaler.inv_scale)
 
-        # Update across all model parallel instances.
-        # TODO (SpiralPipe) Implement all_reduce for found_inf
-        warnings.warn("SpiralPipe currently does not implement all_reduce for found_inf. This is a critical bug when using TP or DP with SpiralPipe. We must implement this later on.")
-        # torch.distributed.all_reduce(self.found_inf,
-        #                             op=torch.distributed.ReduceOp.MAX,
-        #                             group=self.get_model_parallel_group())
-
         # Check for nan.
         found_inf_flag = (self.found_inf.item() > 0)
 
@@ -60,47 +52,44 @@ class SpiralFloat16Optimizer(Float16OptimizerWithFloat16Params):
         if is_cpu_optimizer(self.optimizer):
             return self.optimizer.step()
         else:
-            # parameter is freed in schedule
-            # TODO: don't need to free in schedule
-            for group in self.float16_groups:
-                for p in group:
-                    if is_spiral_param(p):
-                        p.fetch(non_blocking=False)
-
             super().step(args, timers)
 
             for group in self.float16_groups:
                 for p in group:
                     if is_spiral_param(p):
-                        p.offload()
-                        p.free()
+                        p.offload(non_blocking=True)
+                        
+            self.offload_event = get_thunder_cuda_manager().Event(
+                "offload", None, tag="offload"
+            )
+            if get_thunder_cuda_manager().record_event(self.offload_event) == -1:
+                raise RuntimeError("record_event failed")
 
     def sync(self, found_inf=None):
         if is_cpu_optimizer(self.optimizer):
             self.optimizer.sync(found_inf)
         else:
-            # TODO: make event in step and wait until event finished
+            # TODO: check whether wait offload_event or only step_event
+            if self.offload_event is not None:
+                if get_thunder_cuda_manager().wait_event(self.offload_event) == -1:
+                    raise RuntimeError("wait_event failed")
+                self.offload_event = None
+
             found_inf.data = self.found_inf.to(device = found_inf.device, non_blocking=False)
 
+    @torch.no_grad()
     def rollback(self, sync=False):
         if is_cpu_optimizer(self.optimizer):
             self.optimizer.rollback(sync)
         else:
             if self.found_inf.item() == 0:
-                # TODO: don't need to free in schedule
-                for group in self.float16_groups:
-                    for p in group:
-                        if is_spiral_param(p):
-                            p.fetch(non_blocking=False)
-
                 self.optimizer.rollback()
                 self._copy_main_params_to_model_params()
 
                 for group in self.float16_groups:
                     for p in group:
                         if is_spiral_param(p):
-                            p.offload()
-                            p.free()
+                            p.offload(non_blocking=not sync)
 
 
 class SpiralFP32Optimizer(FP32Optimizer):
@@ -109,27 +98,28 @@ class SpiralFP32Optimizer(FP32Optimizer):
         if is_cpu_optimizer(self.optimizer):
             return self.optimizer.step()
         else:
-            # parameter is freed in schedule
-            # TODO: don't need to free in schedule
-            for group in self.optimizer.param_groups:
-                for p in group["params"]:
-                    if is_spiral_param(p):
-                        p.fetch(non_blocking=False)
-
             super().step(args, timers)
 
             for group in self.optimizer.param_groups:
                 for p in group["params"]:
                     if is_spiral_param(p):
-                        p.offload()
-                        p.free()
+                        p.offload(non_blocking=True)
+                        
+            self.offload_event = get_thunder_cuda_manager().Event(
+                "offload", None, tag="offload"
+            )
+            if get_thunder_cuda_manager().record_event(self.offload_event) == -1:
+                raise RuntimeError("record_event failed")
 
     def sync(self, found_inf=None):
         if is_cpu_optimizer(self.optimizer):
             self.optimizer.sync(found_inf)
         else:
-            # TODO: make event in step and wait until event finished
-            pass
+            # TODO: check whether wait offload_event or only step_event
+            if self.offload_event is not None:
+                if get_thunder_cuda_manager().wait_event(self.offload_event) == -1:
+                    raise RuntimeError("wait_event failed")
+                self.offload_event = None
 
     def rollback(self, sync=False):
         # No need to rollback for fp32 param

--- a/megatron/spiral/optimizer/optimizer.py
+++ b/megatron/spiral/optimizer/optimizer.py
@@ -74,7 +74,7 @@ class SpiralFloat16Optimizer(Float16OptimizerWithFloat16Params):
         else:
             # TODO: check whether wait offload_event or only step_event
             if self.offload_event is not None:
-                if get_thunder_cuda_manager().wait_event(self.offload_event) == -1:
+                if get_thunder_cuda_manager().wait_event(self.offload_event, sync=True) == -1:
                     raise RuntimeError("wait_event failed")
                 self.offload_event = None
 
@@ -122,7 +122,7 @@ class SpiralFP32Optimizer(FP32Optimizer):
         else:
             # TODO: check whether wait offload_event or only step_event
             if self.offload_event is not None:
-                if get_thunder_cuda_manager().wait_event(self.offload_event) == -1:
+                if get_thunder_cuda_manager().wait_event(self.offload_event, sync=True) == -1:
                     raise RuntimeError("wait_event failed")
                 self.offload_event = None
 

--- a/megatron/spiral/optimizer/stage_optimizer.py
+++ b/megatron/spiral/optimizer/stage_optimizer.py
@@ -88,7 +88,7 @@ class SpiralStageOptimizer:
         # sync all optimizers
         for optimizer in reversed(self.optimizer_list):
             found_inf = torch.FloatTensor([0])
-            optimizer.optimizer.sync(found_inf)
+            optimizer.sync(found_inf)
             local_found_inf += found_inf.item()
 
         # update grad scaler
@@ -105,7 +105,7 @@ class SpiralStageOptimizer:
         # rollback
         if found_inf_flag:
             for optimizer in self.optimizer_list:
-                optimizer.optimizer.rollback(sync=True)
+                optimizer.rollback(sync=True)
 
         spiral_stage_optimizer_step_returns.appendleft((not found_inf_flag, None, None))
 

--- a/megatron/spiral/optimizer/stage_optimizer.py
+++ b/megatron/spiral/optimizer/stage_optimizer.py
@@ -74,8 +74,8 @@ class SpiralStageOptimizer:
         
         if self.is_cpu_optimizer(idx):
             inner_opt = self.optimizer_list[idx].optimizer
-            inner_opt.set_inv_scale(self.inv_scale_val)
-            inner_opt.set_event_long(event_long)
+            inner_opt.inv_scale = self.inv_scale_val
+            inner_opt.ev_long = event_long
 
         self.optimizer_list[idx].step(args, timers)
 

--- a/megatron/spiral/optimizer/stage_optimizer.py
+++ b/megatron/spiral/optimizer/stage_optimizer.py
@@ -4,6 +4,7 @@ import torch
 
 from megatron.core import mpu
 from megatron.spiral.initialize import get_thunder_cuda_manager
+from megatron.spiral.optimizer.cpu_adam import SpiralCPUAdam
 
 class SpiralStageOptimizer:
 
@@ -58,14 +59,24 @@ class SpiralStageOptimizer:
         """Simple scaling."""
         return self.get_loss_scale() * loss
 
+    def zero_grad(self, set_to_none=True):
+        for optimizer in self.optimizer_list:
+            optimizer.zero_grad(set_to_none)
+
+    def is_cpu_optimizer(self, idx):
+        return isinstance(self.optimizer_list[idx].optimizer, SpiralCPUAdam)
+
     @nvtx.annotate("step", color="cyan")
     def step(self, idx, event_query, args, timers):
         event_long = -1
         if event_query != None:
             event_long = get_thunder_cuda_manager().get_event(event_query).cuda_event
         
-        self.optimizer_list[idx].optimizer.set_inv_scale(self.inv_scale_val)
-        self.optimizer_list[idx].optimizer.set_event_long(event_long)
+        if self.is_cpu_optimizer(idx):
+            inner_opt = self.optimizer_list[idx].optimizer
+            inner_opt.set_inv_scale(self.inv_scale_val)
+            inner_opt.set_event_long(event_long)
+
         self.optimizer_list[idx].step(args, timers)
 
     @nvtx.annotate("join_step", color="red")

--- a/megatron/spiral/schedules/mobius_schedule.py
+++ b/megatron/spiral/schedules/mobius_schedule.py
@@ -595,7 +595,7 @@ def mobius_schedule(
 
     if offload_grad_after_bwd_stage:
         for bwd_stage_id in range(mpu.get_spiral_backward_virtual_size() - 1, -1, -1):
-            # flush free grad event queries
+            # flush offload grad event queries
             if (
                 get_thunder_cuda_manager().wait_event(
                     offload_event_queries.pop(f"offload_grad:b{bwd_stage_id}"),
@@ -605,18 +605,18 @@ def mobius_schedule(
             ):
                 raise RuntimeError("wait_event failed")
 
-    if optimize_after_bwd_stage:
-        for bwd_stage_id in range(mpu.get_spiral_backward_virtual_size() - 1, -1, -1):
-            if not optimizer.is_cpu_optimizer(bwd_stage_id):
-                # flush free grad event queries
-                if (
-                    get_thunder_cuda_manager().wait_event(
-                        offload_event_queries.pop(f"offload_param:b{bwd_stage_id}"),
-                        sync=True
-                    )
-                    == -1
-                ):
-                    raise RuntimeError("wait_event failed")
+        if optimize_after_bwd_stage:
+            for bwd_stage_id in range(mpu.get_spiral_backward_virtual_size() - 1, -1, -1):
+                if not optimizer.is_cpu_optimizer(bwd_stage_id):
+                    # flush offload param event queries
+                    if (
+                        get_thunder_cuda_manager().wait_event(
+                            offload_event_queries.pop(f"offload_param:b{bwd_stage_id}"),
+                            sync=True
+                        )
+                        == -1
+                    ):
+                        raise RuntimeError("wait_event failed")
 
     _cleanup()
     return forward_data_store

--- a/megatron/spiral/schedules/mobius_schedule.py
+++ b/megatron/spiral/schedules/mobius_schedule.py
@@ -1,9 +1,6 @@
 import contextlib
 import warnings
 from typing import Callable, Iterator, List, Optional, Union, Tuple
-from collections import deque
-from queue import Queue
-import threading
 
 import torch
 from torch.nn.parallel.distributed import DistributedDataParallel as torchDDP
@@ -545,16 +542,18 @@ def mobius_schedule(
                     == -1
                 ):
                     raise RuntimeError("wait_event failed")
+
                 # if not spiral stage optimizer, then gradient should be manually reduced
                 if optimize_after_bwd_stage:
                     optimizer[bwd_stage_id].reduce_model_grads(get_args(), get_timers())
                 else:
                     model[bwd_stage_id].allreduce_gradients()
+
                 # offload grads
                 model[bwd_stage_id].spiral_offload_grad(non_blocking=True)
                 offload_grad_curr = get_thunder_cuda_manager().Event(
                     "offload",
-                    "free",
+                    None,
                     tag=f"offload_grad:b{bwd_stage_id}"
                 )
                 if get_thunder_cuda_manager().record_event(offload_grad_curr) == -1:
@@ -565,23 +564,8 @@ def mobius_schedule(
                 if optimize_after_bwd_stage:
                     optimizer.step(bwd_stage_id, offload_grad_curr, get_args(), get_timers())
 
-            with torch.cuda.stream(get_thunder_cuda_manager().Stream("free")):
-                if (
-                    get_thunder_cuda_manager().wait_event(offload_event_queries.pop(f"offload_grad:b{bwd_stage_id}"))
-                    == -1
-                ):
-                    raise RuntimeError("wait_event failed")
-
-                # free bwd stage grads
+                # free bwd stage grads (spiral_free_grad is cpu job with tensor.record_stream)
                 model[bwd_stage_id].spiral_free_grad()
-                free_grad_curr = get_thunder_cuda_manager().Event(
-                    "free",
-                    None,
-                    tag=f"free_grad:b{bwd_stage_id}",
-                )
-                if get_thunder_cuda_manager().record_event(free_grad_curr) == -1:
-                    raise RuntimeError("record_event failed")
-                free_event_queries[free_grad_curr.tag] = free_grad_curr
         # end offload & free grad
 
         mpu.set_spiral_backward_virtual_rank(None)
@@ -599,7 +583,7 @@ def mobius_schedule(
             # flush free grad event queries
             if (
                 get_thunder_cuda_manager().wait_event(
-                    free_event_queries.pop(f"free_grad:b{bwd_stage_id}")
+                    offload_event_queries.pop(f"offload_grad:b{bwd_stage_id}")
                 )
                 == -1
             ):

--- a/megatron/spiral/schedules/mobius_schedule.py
+++ b/megatron/spiral/schedules/mobius_schedule.py
@@ -523,7 +523,8 @@ def mobius_schedule(
                 raise RuntimeError("wait_event failed")
 
             # free bwd stage
-            model[bwd_stage_id].spiral_free()
+            if optimizer.is_cpu_optimizer(bwd_stage_id):
+                model[bwd_stage_id].spiral_free()
             free_curr = get_thunder_cuda_manager().Event(
                 "free",
                 None if bwd_stage_id == 0 else "prefetch",

--- a/megatron/spiral/schedules/mobius_schedule.py
+++ b/megatron/spiral/schedules/mobius_schedule.py
@@ -129,6 +129,13 @@ def mobius_schedule(
         assert "spiral_stage_optimizer" in kwargs
         optimizer = kwargs["spiral_stage_optimizer"]
 
+    def _is_cpu_optimizer(bwd_stage_id):
+        if get_args().spiral_stage_optimizer:
+            return optimizer.is_cpu_optimizer(bwd_stage_id)
+        else:
+            # If the stage optimizer is not enabled, the optimizer should always be the CPU optimizer.
+            return True
+
     def _cleanup():
         # cleanup checkpointed input tensors and output tensors
         for module in model:
@@ -523,7 +530,7 @@ def mobius_schedule(
                 raise RuntimeError("wait_event failed")
 
             # free bwd stage
-            if not optimize_after_bwd_stage or optimizer.is_cpu_optimizer(bwd_stage_id):
+            if _is_cpu_optimizer(bwd_stage_id):
                 model[bwd_stage_id].spiral_free()
             free_curr = get_thunder_cuda_manager().Event(
                 "free",
@@ -551,7 +558,7 @@ def mobius_schedule(
                     model[bwd_stage_id].allreduce_gradients()
 
                 # offload grads
-                if not optimize_after_bwd_stage or optimizer.is_cpu_optimizer(bwd_stage_id):
+                if _is_cpu_optimizer(bwd_stage_id):
                     model[bwd_stage_id].spiral_offload_grad(non_blocking=True)
                 offload_grad_curr = get_thunder_cuda_manager().Event(
                     "offload",

--- a/megatron/spiral/schedules/mobius_schedule.py
+++ b/megatron/spiral/schedules/mobius_schedule.py
@@ -550,7 +550,8 @@ def mobius_schedule(
                     model[bwd_stage_id].allreduce_gradients()
 
                 # offload grads
-                model[bwd_stage_id].spiral_offload_grad(non_blocking=True)
+                if optimizer.is_cpu_optimizer(bwd_stage_id):
+                    model[bwd_stage_id].spiral_offload_grad(non_blocking=True)
                 offload_grad_curr = get_thunder_cuda_manager().Event(
                     "offload",
                     None,
@@ -565,7 +566,8 @@ def mobius_schedule(
                     optimizer.step(bwd_stage_id, offload_grad_curr, get_args(), get_timers())
 
                 # free bwd stage grads (spiral_free_grad is cpu job with tensor.record_stream)
-                model[bwd_stage_id].spiral_free_grad()
+                if optimizer.is_cpu_optimizer(bwd_stage_id):
+                    model[bwd_stage_id].spiral_free_grad()
         # end offload & free grad
 
         mpu.set_spiral_backward_virtual_rank(None)

--- a/megatron/spiral/schedules/mobius_schedule.py
+++ b/megatron/spiral/schedules/mobius_schedule.py
@@ -566,6 +566,18 @@ def mobius_schedule(
                 if optimize_after_bwd_stage:
                     optimizer.step(bwd_stage_id, offload_grad_curr, get_args(), get_timers())
 
+                    # for gpu optimizer, need to offload parameter (not free to reuse in next iteration)
+                    if not optimizer.is_cpu_optimizer(bwd_stage_id):
+                        model[bwd_stage_id].spiral_offload(non_blocking=True)
+                        offload_param_curr = get_thunder_cuda_manager().Event(
+                            "offload",
+                            None,
+                            tag=f"offload_param:b{bwd_stage_id}"
+                        )
+                        if get_thunder_cuda_manager().record_event(offload_param_curr) == -1:
+                            raise RuntimeError("record_event failed")
+                        offload_event_queries[offload_param_curr.tag] = offload_param_curr
+
                 # free bwd stage grads (spiral_free_grad is cpu job with tensor.record_stream)
                 model[bwd_stage_id].spiral_free_grad()
         # end offload & free grad
@@ -592,6 +604,19 @@ def mobius_schedule(
                 == -1
             ):
                 raise RuntimeError("wait_event failed")
+
+    if optimize_after_bwd_stage:
+        for bwd_stage_id in range(mpu.get_spiral_backward_virtual_size() - 1, -1, -1):
+            if not optimizer.is_cpu_optimizer(bwd_stage_id):
+                # flush free grad event queries
+                if (
+                    get_thunder_cuda_manager().wait_event(
+                        offload_event_queries.pop(f"offload_param:b{bwd_stage_id}"),
+                        sync=True
+                    )
+                    == -1
+                ):
+                    raise RuntimeError("wait_event failed")
 
     _cleanup()
     return forward_data_store

--- a/megatron/spiral/schedules/mobius_schedule.py
+++ b/megatron/spiral/schedules/mobius_schedule.py
@@ -566,8 +566,7 @@ def mobius_schedule(
                     optimizer.step(bwd_stage_id, offload_grad_curr, get_args(), get_timers())
 
                 # free bwd stage grads (spiral_free_grad is cpu job with tensor.record_stream)
-                if optimizer.is_cpu_optimizer(bwd_stage_id):
-                    model[bwd_stage_id].spiral_free_grad()
+                model[bwd_stage_id].spiral_free_grad()
         # end offload & free grad
 
         mpu.set_spiral_backward_virtual_rank(None)

--- a/megatron/spiral/schedules/mobius_schedule.py
+++ b/megatron/spiral/schedules/mobius_schedule.py
@@ -523,7 +523,7 @@ def mobius_schedule(
                 raise RuntimeError("wait_event failed")
 
             # free bwd stage
-            if optimizer.is_cpu_optimizer(bwd_stage_id):
+            if not optimize_after_bwd_stage or optimizer.is_cpu_optimizer(bwd_stage_id):
                 model[bwd_stage_id].spiral_free()
             free_curr = get_thunder_cuda_manager().Event(
                 "free",
@@ -551,7 +551,7 @@ def mobius_schedule(
                     model[bwd_stage_id].allreduce_gradients()
 
                 # offload grads
-                if optimizer.is_cpu_optimizer(bwd_stage_id):
+                if not optimize_after_bwd_stage or optimizer.is_cpu_optimizer(bwd_stage_id):
                     model[bwd_stage_id].spiral_offload_grad(non_blocking=True)
                 offload_grad_curr = get_thunder_cuda_manager().Event(
                     "offload",

--- a/megatron/spiral/schedules/mobius_schedule.py
+++ b/megatron/spiral/schedules/mobius_schedule.py
@@ -575,7 +575,8 @@ def mobius_schedule(
 
     # cleanup schedule events
     if (
-        get_thunder_cuda_manager().wait_event(free_event_queries.pop(f"free:b0"))
+        get_thunder_cuda_manager().wait_event(free_event_queries.pop(f"free:b0"),
+                                              sync=True)
         == -1
     ):
         raise RuntimeError("wait_event failed")
@@ -585,7 +586,8 @@ def mobius_schedule(
             # flush free grad event queries
             if (
                 get_thunder_cuda_manager().wait_event(
-                    offload_event_queries.pop(f"offload_grad:b{bwd_stage_id}")
+                    offload_event_queries.pop(f"offload_grad:b{bwd_stage_id}"),
+                    sync=True
                 )
                 == -1
             ):

--- a/megatron/spiral/schedules/spipe_schedule.py
+++ b/megatron/spiral/schedules/spipe_schedule.py
@@ -129,6 +129,13 @@ def spipe_schedule(
         assert "spiral_stage_optimizer" in kwargs
         optimizer = kwargs["spiral_stage_optimizer"]
 
+    def _is_cpu_optimizer(bwd_stage_id):
+        if get_args().spiral_stage_optimizer:
+            return optimizer.is_cpu_optimizer(bwd_stage_id)
+        else:
+            # If the stage optimizer is not enabled, the optimizer should always be the CPU optimizer.
+            return True
+
     def _cleanup():
         # cleanup checkpointed input tensors
         for module in model:
@@ -532,7 +539,7 @@ def spipe_schedule(
                 raise RuntimeError("wait_event failed")
 
             # free bwd stage
-            if not optimize_after_bwd_stage or optimizer.is_cpu_optimizer(bwd_stage_id):
+            if _is_cpu_optimizer(bwd_stage_id):
                 model[-bwd_stage_id - 1].spiral_free()
             free_curr = get_thunder_cuda_manager().Event(
                 "free",
@@ -560,7 +567,7 @@ def spipe_schedule(
                     model[-bwd_stage_id - 1].allreduce_gradients()
 
                 # offload grads
-                if not optimize_after_bwd_stage or optimizer.is_cpu_optimizer(bwd_stage_id):
+                if _is_cpu_optimizer(bwd_stage_id):
                     model[-bwd_stage_id - 1].spiral_offload_grad(non_blocking=True)
                 offload_grad_curr = get_thunder_cuda_manager().Event(
                     "offload",

--- a/megatron/spiral/schedules/spipe_schedule.py
+++ b/megatron/spiral/schedules/spipe_schedule.py
@@ -575,6 +575,19 @@ def spipe_schedule(
                 if optimize_after_bwd_stage:
                     optimizer.step(bwd_stage_id, offload_grad_curr, get_args(), get_timers())
 
+                    # for gpu optimizer, need to offload/free parameter
+                    if not optimizer.is_cpu_optimizer(bwd_stage_id):
+                        model[-bwd_stage_id - 1].spiral_offload(non_blocking=True)
+                        model[-bwd_stage_id - 1].spiral_free()
+                        offload_param_curr = get_thunder_cuda_manager().Event(
+                            "offload",
+                            None,
+                            tag=f"offload_param:b{bwd_stage_id}"
+                        )
+                        if get_thunder_cuda_manager().record_event(offload_param_curr) == -1:
+                            raise RuntimeError("record_event failed")
+                        offload_event_queries[offload_param_curr.tag] = offload_param_curr
+
                 # free bwd stage grads (spiral_free_grad is cpu job with tensor.record_stream)
                 model[-bwd_stage_id - 1].spiral_free_grad()
         # end offload & free grad
@@ -619,6 +632,19 @@ def spipe_schedule(
                 == -1
             ):
                 raise RuntimeError("wait_event failed")
+
+    if optimize_after_bwd_stage:
+        for bwd_stage_id in range(mpu.get_spiral_backward_virtual_size() - 1, -1, -1):
+            if not optimizer.is_cpu_optimizer(bwd_stage_id):
+                # flush free grad event queries
+                if (
+                    get_thunder_cuda_manager().wait_event(
+                        offload_event_queries.pop(f"offload_param:b{bwd_stage_id}"),
+                        sync=True
+                    )
+                    == -1
+                ):
+                    raise RuntimeError("wait_event failed")
 
     _cleanup()
     return forward_data_store

--- a/megatron/spiral/schedules/spipe_schedule.py
+++ b/megatron/spiral/schedules/spipe_schedule.py
@@ -600,7 +600,8 @@ def spipe_schedule(
 
     # cleanup schedule events
     if (
-        get_thunder_cuda_manager().wait_event(free_event_queries.pop(f"free:b0"))
+        get_thunder_cuda_manager().wait_event(free_event_queries.pop(f"free:b0"),
+                                              sync=True)
         == -1
     ):
         raise RuntimeError("wait_event failed")
@@ -610,7 +611,8 @@ def spipe_schedule(
             # flush free grad event queries
             if (
                 get_thunder_cuda_manager().wait_event(
-                    offload_event_queries.pop(f"offload_grad:b{bwd_stage_id}")
+                    offload_event_queries.pop(f"offload_grad:b{bwd_stage_id}"),
+                    sync=True
                 )
                 == -1
             ):

--- a/megatron/spiral/schedules/spipe_schedule.py
+++ b/megatron/spiral/schedules/spipe_schedule.py
@@ -532,7 +532,8 @@ def spipe_schedule(
                 raise RuntimeError("wait_event failed")
 
             # free bwd stage
-            model[-bwd_stage_id - 1].spiral_free()
+            if not optimize_after_bwd_stage or optimizer.is_cpu_optimizer(bwd_stage_id):
+                model[-bwd_stage_id - 1].spiral_free()
             free_curr = get_thunder_cuda_manager().Event(
                 "free",
                 None if bwd_stage_id == 0 else "prefetch",
@@ -559,7 +560,8 @@ def spipe_schedule(
                     model[-bwd_stage_id - 1].allreduce_gradients()
 
                 # offload grads
-                model[-bwd_stage_id - 1].spiral_offload_grad(non_blocking=True)
+                if not optimize_after_bwd_stage or optimizer.is_cpu_optimizer(bwd_stage_id):
+                    model[-bwd_stage_id - 1].spiral_offload_grad(non_blocking=True)
                 offload_grad_curr = get_thunder_cuda_manager().Event(
                     "offload",
                     None,

--- a/megatron/spiral/schedules/spipe_schedule.py
+++ b/megatron/spiral/schedules/spipe_schedule.py
@@ -1,9 +1,6 @@
 import contextlib
 import warnings
 from typing import Callable, Iterator, List, Optional, Union, Tuple
-from collections import deque
-from queue import Queue
-import threading
 
 import torch
 from torch.nn.parallel.distributed import DistributedDataParallel as torchDDP
@@ -554,16 +551,18 @@ def spipe_schedule(
                     == -1
                 ):
                     raise RuntimeError("wait_event failed")
+
                 # if not spiral stage optimizer, then gradient should be manually reduced
                 if optimize_after_bwd_stage:
                     optimizer[bwd_stage_id].reduce_model_grads(get_args(), get_timers())
                 else:
                     model[-bwd_stage_id - 1].allreduce_gradients()
+
                 # offload grads
                 model[-bwd_stage_id - 1].spiral_offload_grad(non_blocking=True)
                 offload_grad_curr = get_thunder_cuda_manager().Event(
                     "offload",
-                    "free",
+                    None,
                     tag=f"offload_grad:b{bwd_stage_id}"
                 )
                 if get_thunder_cuda_manager().record_event(offload_grad_curr) == -1:
@@ -574,23 +573,8 @@ def spipe_schedule(
                 if optimize_after_bwd_stage:
                     optimizer.step(bwd_stage_id, offload_grad_curr, get_args(), get_timers())
 
-            with torch.cuda.stream(get_thunder_cuda_manager().Stream("free")):
-                if (
-                    get_thunder_cuda_manager().wait_event(offload_event_queries.pop(f"offload_grad:b{bwd_stage_id}"))
-                    == -1
-                ):
-                    raise RuntimeError("wait_event failed")
-
-                # free bwd stage grads
+                # free bwd stage grads (spiral_free_grad is cpu job with tensor.record_stream)
                 model[-bwd_stage_id - 1].spiral_free_grad()
-                free_grad_curr = get_thunder_cuda_manager().Event(
-                    "free",
-                    None,
-                    tag=f"free_grad:b{bwd_stage_id}",
-                )
-                if get_thunder_cuda_manager().record_event(free_grad_curr) == -1:
-                    raise RuntimeError("record_event failed")
-                free_event_queries[free_grad_curr.tag] = free_grad_curr
         # end offload & free grad
 
         mpu.set_spiral_backward_virtual_rank(None)
@@ -626,7 +610,7 @@ def spipe_schedule(
             # flush free grad event queries
             if (
                 get_thunder_cuda_manager().wait_event(
-                    free_event_queries.pop(f"free_grad:b{bwd_stage_id}")
+                    offload_event_queries.pop(f"offload_grad:b{bwd_stage_id}")
                 )
                 == -1
             ):

--- a/megatron/spiral/schedules/spipe_schedule.py
+++ b/megatron/spiral/schedules/spipe_schedule.py
@@ -623,7 +623,7 @@ def spipe_schedule(
 
     if offload_grad_after_bwd_stage:
         for bwd_stage_id in range(mpu.get_spiral_backward_virtual_size() - 1, -1, -1):
-            # flush free grad event queries
+            # flush offload grad event queries
             if (
                 get_thunder_cuda_manager().wait_event(
                     offload_event_queries.pop(f"offload_grad:b{bwd_stage_id}"),
@@ -633,18 +633,18 @@ def spipe_schedule(
             ):
                 raise RuntimeError("wait_event failed")
 
-    if optimize_after_bwd_stage:
-        for bwd_stage_id in range(mpu.get_spiral_backward_virtual_size() - 1, -1, -1):
-            if not optimizer.is_cpu_optimizer(bwd_stage_id):
-                # flush free grad event queries
-                if (
-                    get_thunder_cuda_manager().wait_event(
-                        offload_event_queries.pop(f"offload_param:b{bwd_stage_id}"),
-                        sync=True
-                    )
-                    == -1
-                ):
-                    raise RuntimeError("wait_event failed")
+        if optimize_after_bwd_stage:
+            for bwd_stage_id in range(mpu.get_spiral_backward_virtual_size() - 1, -1, -1):
+                if not optimizer.is_cpu_optimizer(bwd_stage_id):
+                    # flush offload param event queries
+                    if (
+                        get_thunder_cuda_manager().wait_event(
+                            offload_event_queries.pop(f"offload_param:b{bwd_stage_id}"),
+                            sync=True
+                        )
+                        == -1
+                    ):
+                        raise RuntimeError("wait_event failed")
 
     _cleanup()
     return forward_data_store

--- a/megatron/training.py
+++ b/megatron/training.py
@@ -872,7 +872,6 @@ def train_step(forward_step_func, data_iterator,
                 model[_idx_bwd_stage_id].spiral_offload_grad(non_blocking=False) # blocking offload gradients
                 model[_idx_bwd_stage_id].spiral_free_grad()
         else:
-            torch.cuda.synchronize() # To ensure non_blocking offload finished
             # Assert gradients are already offloaded and freed on GPU
             for bwd_stage_id in range(mpu.get_spiral_backward_virtual_size()):
                 _idx_bwd_stage_id = -bwd_stage_id - 1 if args.spiral_remap else bwd_stage_id

--- a/megatron/training.py
+++ b/megatron/training.py
@@ -817,11 +817,7 @@ def train_step(forward_step_func, data_iterator,
     if args.DDP_impl == 'local' and args.use_contiguous_buffers_in_local_ddp:
         for partition in model:
             partition.zero_grad_buffer()
-    if args.spiral_stage_optimizer:
-        for opt_ty in getattr(optimizer, "optimizer_list"):
-            opt_ty.zero_grad()
-    else:
-        optimizer.zero_grad()
+    optimizer.zero_grad()
 
     # Forward pass.
     timers('forward-backward', log_level=1).start(


### PR DESCRIPTION
### Feature
In staged optimizer, parameter update (cpu job) is overlapped by fwd, bwd computation (gpu job).
However, GPU do nothing while paramter update of first stage.
This PR resolve this by apply gpu optimizer for first stage and this can be run by add `--spiral-heterogeneous-optimizer` option.

- Add `SpiralGPUAdam` which is based on `FusedAdam` of NVIDIA apex.
- Modify schedule logic to support gpu_optimizer stage.
- (misc) Keep `DeepSpeedCPUAdam` as baseline and create `DeepSpeedFloat16Optimizer` which is divided from `SpiralFloat16Optimizer`

### TODO
- I will move some mixed precision logic in `SpiralFloat16Optimizer` to `SpiralGPUOptimizer`
- Currently, first stage gpu optimizer hold optimizer state (momentum, variance, param32). To save gpu memory, we need to prefetch and offload optimizer state per parameter tensor.

(+) Reslove #15 and #30 