### PR TITLE
Make SpiralGPUAdam handle mixed precision logic

### DIFF
--- a/megatron/optimizer/optimizer.py
+++ b/megatron/optimizer/optimizer.py
@@ -345,7 +345,6 @@ class MixedPrecisionOptimizer(MegatronOptimizer):
         self.bf16 = bf16
         self.params_dtype = params_dtype
         self.grad_scaler = grad_scaler
-        self.use_global_grad_scaler = False
 
         # None grad scaler is only supported for bf16.
         if self.grad_scaler is None:
@@ -425,9 +424,7 @@ class MixedPrecisionOptimizer(MegatronOptimizer):
 
             # We are done with scaling gradients
             # so we can update the loss scale.
-            # TODO: Remove this condition and self.use_global_grad_scaler (dummy flag)
-            if not self.use_global_grad_scaler:
-                self.grad_scaler.update(found_inf_flag)
+            self.grad_scaler.update(found_inf_flag)
 
             # If we found inf/nan, skip the update.
             if found_inf_flag:

--- a/megatron/spiral/optimizer/gpu_adam.py
+++ b/megatron/spiral/optimizer/gpu_adam.py
@@ -53,6 +53,7 @@ class SpiralGPUAdam(torch.optim.Optimizer):
         # For unscale in mixed precision
         self.inv_scale = 0
         self.params_have_main_grad = True
+        self.step_event = None
 
         if multi_tensor_applier.available:
             import amp_C
@@ -146,7 +147,7 @@ class SpiralGPUAdam(torch.optim.Optimizer):
 
                 group['found_inf'] = (found_inf.item() > 0)
                 if group['found_inf']:
-                    return False
+                    return loss
 
             # assume same step across group now to simplify things
             # per parameter step can be easily support by making it tensor, or pass list into kernel
@@ -177,12 +178,13 @@ class SpiralGPUAdam(torch.optim.Optimizer):
                                      [p_32, p_16],
                                      1.0)
 
-        return True
+        self.step_event = torch.cuda.Event()
+        self.step_event.record()
+        return loss
 
     def rollback(self):
         if not self.adam_w_mode:
             raise RuntimeError("SpiralGPUAdam only supports rollback for adam_w_mode.")
-        loss = None
 
         for group in self.param_groups:
             if len(group['params']) == 0:
@@ -194,7 +196,7 @@ class SpiralGPUAdam(torch.optim.Optimizer):
             # if found_inf is True, skip rollback
             if dtype == torch.float16:
                 if group['found_inf']:
-                    return False
+                    return
 
             # create lists for multi-tensor apply
             p_16 = []
@@ -232,7 +234,18 @@ class SpiralGPUAdam(torch.optim.Optimizer):
                                      [p_32, p_16],
                                      1.0)
 
-        return True
+    def sync(self, found_inf=None):
+        if self.step_event is not None:
+            self.step_event.synchronize()
+            self.step_event = None
+
+        if found_inf is not None:
+            flag = 0
+            for group in self.param_groups:
+                if group['found_inf']:
+                    flag = 1
+                    break
+            found_inf.fill_(flag)
 
 
 def multi_tensor_rollback_adamw(

--- a/megatron/spiral/optimizer/gpu_adam.py
+++ b/megatron/spiral/optimizer/gpu_adam.py
@@ -50,13 +50,16 @@ class SpiralGPUAdam(torch.optim.Optimizer):
         self.adam_w_mode = 1 if adam_w_mode else 0
         self.set_grad_none = set_grad_none
 
+        # For unscale in mixed precision
+        self.inv_scale = 0
+        self.params_have_main_grad = True
+
         if multi_tensor_applier.available:
             import amp_C
             # Skip buffer
             self._dummy_overflow_buf = torch.cuda.IntTensor([0])
             self.multi_tensor_adam = amp_C.multi_tensor_adam
-            self.multi_tensor_adam_capturable = amp_C.multi_tensor_adam_capturable
-            self.multi_tensor_adam_capturable_master = amp_C.multi_tensor_adam_capturable_master
+            self.multi_tensor_scale = amp_C.multi_tensor_scale
         else:
             raise RuntimeError('SpiralGPUAdam requires cuda extensions')
 
@@ -65,6 +68,9 @@ class SpiralGPUAdam(torch.optim.Optimizer):
             for group in self.param_groups:
                 for p in group['params']:
                     p.grad = None
+                    state = self.state[p]
+                    if 'fp32_grad' in state:
+                        state['fp32_grad'] = None
         else:
             super(SpiralGPUAdam, self).zero_grad()
 
@@ -86,26 +92,25 @@ class SpiralGPUAdam(torch.optim.Optimizer):
         for group in self.param_groups:
             if len(group['params']) == 0:
                 continue
-            device = group['params'][0].device
+            dtype = group['params'][0].dtype
             bias_correction = 1 if group['bias_correction'] else 0
             beta1, beta2 = group['betas']
 
-            # assume same step across group now to simplify things
-            # per parameter step can be easily support by making it tensor, or pass list into kernel
-            if 'step' in group:
-                group['step'] += 1
-            else:
-                group['step'] = 1
+            group['found_inf'] = False
 
             # create lists for multi-tensor apply
-            g_16, p_16, m_16, v_16 = [], [], [], []
-            g_bf, p_bf, m_bf, v_bf = [], [], [], []
+            p_16 = []
             g_32, p_32, m_32, v_32 = [], [], [], []
 
             for p in group['params']:
-                if p.grad is None:
+                if self.params_have_main_grad and hasattr(p, 'main_grad'):
+                    grad = p.main_grad
+                else:
+                    grad = p.grad
+
+                if grad is None:
                     continue
-                if p.grad.data.is_sparse:
+                if grad.data.is_sparse:
                     raise RuntimeError('SpiralGPUAdam does not support sparse gradients, please consider SparseAdam instead')
 
                 state = self.state[p]
@@ -115,52 +120,42 @@ class SpiralGPUAdam(torch.optim.Optimizer):
                     state['exp_avg'] = torch.zeros_like(p.data).float()
                     # Exponential moving average of squared gradient values
                     state['exp_avg_sq'] = torch.zeros_like(p.data).float()
+                    # Copy fp16 param to fp32 param
+                    if dtype == torch.float16 or dtype == torch.bfloat16:
+                        state['fp32_param'] = p.detach().clone().float()
+                    else:
+                        state['fp32_param'] = p
 
-                if p.dtype == torch.float16:
-                    g_16.append(p.grad.data)
+                # Copy fp16 grad to fp32 grad
+                state['fp32_grad'] = grad.detach().clone().float()
+                grad = None
+
+                if dtype == torch.float16 or dtype == torch.bfloat16:
                     p_16.append(p.data)
-                    m_16.append(state['exp_avg'])
-                    v_16.append(state['exp_avg_sq'])
-                elif p.dtype == torch.bfloat16:
-                    g_bf.append(p.grad)
-                    p_bf.append(p)
-                    m_bf.append(state['exp_avg'])
-                    v_bf.append(state['exp_avg_sq'])
-                elif p.dtype == torch.float32:
-                    g_32.append(p.grad.data)
-                    p_32.append(p.data)
-                    m_32.append(state['exp_avg'])
-                    v_32.append(state['exp_avg_sq'])
-                else:
-                    raise RuntimeError('SpiralGPUAdam only support fp16 and fp32.')
 
-            if len(g_16) > 0:
-                multi_tensor_applier(self.multi_tensor_adam,
-                        self._dummy_overflow_buf,
-                        [g_16, p_16, m_16, v_16],
-                        group['lr'],
-                        beta1,
-                        beta2,
-                        group['eps'],
-                        group['step'],
-                        self.adam_w_mode,
-                        bias_correction,
-                        group['weight_decay'])
+                g_32.append(state['fp32_grad'].data)
+                p_32.append(state['fp32_param'].data)
+                m_32.append(state['exp_avg'])
+                v_32.append(state['exp_avg_sq'])
 
-            if len(g_bf) > 0:
-                multi_tensor_applier(
-                        self.multi_tensor_adam,
-                        self._dummy_overflow_buf,
-                        [g_bf, p_bf, m_bf, v_bf],
-                        group['lr'],
-                        beta1,
-                        beta2,
-                        group['eps'],
-                        group['step'],
-                        self.adam_w_mode,
-                        bias_correction,
-                        group['weight_decay'])
+            # Unscale fp32 grads and check for inf/nan
+            if dtype == torch.float16:
+                found_inf = torch.cuda.FloatTensor([0.0])
+                inv_scale = torch.cuda.FloatTensor([self.inv_scale])
+                torch._amp_foreach_non_finite_check_and_unscale_(g_32, found_inf, inv_scale)
 
+                group['found_inf'] = (found_inf.item() > 0)
+                if group['found_inf']:
+                    return False
+
+            # assume same step across group now to simplify things
+            # per parameter step can be easily support by making it tensor, or pass list into kernel
+            if 'step' in group:
+                group['step'] += 1
+            else:
+                group['step'] = 1
+
+            # Parameter update
             if len(g_32) > 0:
                 multi_tensor_applier(self.multi_tensor_adam,
                         self._dummy_overflow_buf,
@@ -174,7 +169,15 @@ class SpiralGPUAdam(torch.optim.Optimizer):
                         bias_correction,
                         group['weight_decay'])
 
-        return loss
+            # Copy fp32 params to fp16 params
+            if dtype == torch.float16 or dtype == torch.bfloat16:
+                # Scaling with factor `1.0` is equivalent to copy.
+                multi_tensor_applier(self.multi_tensor_scale,
+                                     self._dummy_overflow_buf,
+                                     [p_32, p_16],
+                                     1.0)
+
+        return True
 
     def rollback(self):
         if not self.adam_w_mode:
@@ -184,63 +187,30 @@ class SpiralGPUAdam(torch.optim.Optimizer):
         for group in self.param_groups:
             if len(group['params']) == 0:
                 continue
-
+            dtype = group['params'][0].dtype
             bias_correction = 1 if group['bias_correction'] else 0
             beta1, beta2 = group['betas']
 
+            # if found_inf is True, skip rollback
+            if dtype == torch.float16:
+                if group['found_inf']:
+                    return False
+
             # create lists for multi-tensor apply
-            g_16, p_16, m_16, v_16 = [], [], [], []
-            g_bf, p_bf, m_bf, v_bf = [], [], [], []
+            p_16 = []
             g_32, p_32, m_32, v_32 = [], [], [], []
 
             for p in group['params']:
-                if p.grad is None:
-                    continue
-                if p.grad.data.is_sparse:
-                    raise RuntimeError('SpiralGPUAdam does not support sparse gradients, please consider SparseAdam instead')
-
                 state = self.state[p]
                 assert len(state) != 0, "Rollback should be call after run optimizer.step"
 
-                if p.dtype == torch.float16:
-                    g_16.append(p.grad.data)
+                if dtype == torch.float16 or dtype == torch.bfloat16:
                     p_16.append(p.data)
-                    m_16.append(state['exp_avg'])
-                    v_16.append(state['exp_avg_sq'])
-                elif p.dtype == torch.bfloat16:
-                    g_bf.append(p.grad)
-                    p_bf.append(p)
-                    m_bf.append(state['exp_avg'])
-                    v_bf.append(state['exp_avg_sq'])
-                elif p.dtype == torch.float32:
-                    g_32.append(p.grad.data)
-                    p_32.append(p.data)
-                    m_32.append(state['exp_avg'])
-                    v_32.append(state['exp_avg_sq'])
-                else:
-                    raise RuntimeError('SpiralGPUAdam only support fp16 and fp32.')
 
-            if len(g_16) > 0:
-                multi_tensor_rollback_adamw(
-                    g_16, p_16, m_16, v_16,
-                    group['lr'],
-                    beta1,
-                    beta2,
-                    group['eps'],
-                    group['step'],
-                    bias_correction,
-                    group['weight_decay'])
-
-            if len(g_bf) > 0:
-                multi_tensor_rollback_adamw(
-                    g_bf, p_bf, m_bf, v_bf,
-                    group['lr'],
-                    beta1,
-                    beta2,
-                    group['eps'],
-                    group['step'],
-                    bias_correction,
-                    group['weight_decay'])
+                g_32.append(state['fp32_grad'].data)
+                p_32.append(state['fp32_param'].data)
+                m_32.append(state['exp_avg'])
+                v_32.append(state['exp_avg_sq'])
 
             if len(g_32) > 0:
                 multi_tensor_rollback_adamw(
@@ -254,7 +224,15 @@ class SpiralGPUAdam(torch.optim.Optimizer):
                     group['weight_decay'])
             group['step'] -= 1
 
-        return loss
+            # Copy fp32 params to fp16 params
+            if dtype == torch.float16 or dtype == torch.bfloat16:
+                # Scaling with factor `1.0` is equivalent to copy.
+                multi_tensor_applier(self.multi_tensor_scale,
+                                     self._dummy_overflow_buf,
+                                     [p_32, p_16],
+                                     1.0)
+
+        return True
 
 
 def multi_tensor_rollback_adamw(

--- a/megatron/spiral/optimizer/gpu_adam.py
+++ b/megatron/spiral/optimizer/gpu_adam.py
@@ -5,6 +5,8 @@
 
 import torch
 from apex.multi_tensor_apply import multi_tensor_applier
+from megatron import get_args
+
 
 class SpiralGPUAdam(torch.optim.Optimizer):
 
@@ -51,6 +53,7 @@ class SpiralGPUAdam(torch.optim.Optimizer):
         self.set_grad_none = set_grad_none
 
         # For unscale in mixed precision
+        self.half_precision = get_args().fp16
         self.inv_scale = 0
         self.params_have_main_grad = True
         self.step_event = None
@@ -69,11 +72,27 @@ class SpiralGPUAdam(torch.optim.Optimizer):
             for group in self.param_groups:
                 for p in group['params']:
                     p.grad = None
-                    state = self.state[p]
-                    if 'fp32_grad' in state:
-                        state['fp32_grad'] = None
         else:
             super(SpiralGPUAdam, self).zero_grad()
+
+    def _unscale_grads_and_check_inf(self):
+        fp32_grads = []
+        for group in self.param_groups:
+            for p in group['params']:
+                if self.params_have_main_grad and hasattr(p, 'main_grad'):
+                    if p.main_grad is not None:
+                        p.main_grad = p.main_grad.float()
+                        fp32_grads.append(p.main_grad.data)
+                else:
+                    if p.grad is not None:
+                        p.grad = p.grad.float()
+                        fp32_grads.append(p.grad.data)
+
+        found_inf = torch.cuda.FloatTensor([0.0])
+        inv_scale = torch.cuda.FloatTensor([self.inv_scale])
+        torch._amp_foreach_non_finite_check_and_unscale_(fp32_grads, found_inf, inv_scale)
+
+        return found_inf.item() > 0
 
     def step(self, closure=None, grads=None, output_params=None, scale=None, grad_norms=None, grad_scaler=None):
         """Performs a single optimization step.
@@ -90,6 +109,12 @@ class SpiralGPUAdam(torch.optim.Optimizer):
         if closure is not None:
             loss = closure()
 
+        # Unscale fp32 grads and check for inf/nan
+        if self.half_precision:
+            self.found_inf = self._unscale_grads_and_check_inf()
+            if self.found_inf:
+                return loss
+
         for group in self.param_groups:
             if len(group['params']) == 0:
                 continue
@@ -97,7 +122,12 @@ class SpiralGPUAdam(torch.optim.Optimizer):
             bias_correction = 1 if group['bias_correction'] else 0
             beta1, beta2 = group['betas']
 
-            group['found_inf'] = False
+            # assume same step across group now to simplify things
+            # per parameter step can be easily support by making it tensor, or pass list into kernel
+            if 'step' in group:
+                group['step'] += 1
+            else:
+                group['step'] = 1
 
             # create lists for multi-tensor apply
             p_16 = []
@@ -126,9 +156,8 @@ class SpiralGPUAdam(torch.optim.Optimizer):
                         state['fp32_param'] = p.detach().clone().float()
                     else:
                         state['fp32_param'] = p
-
-                # Copy fp16 grad to fp32 grad
-                state['fp32_grad'] = grad.detach().clone().float()
+                
+                state['fp32_grad'] = grad
                 grad = None
 
                 if dtype == torch.float16 or dtype == torch.bfloat16:
@@ -138,23 +167,6 @@ class SpiralGPUAdam(torch.optim.Optimizer):
                 p_32.append(state['fp32_param'].data)
                 m_32.append(state['exp_avg'])
                 v_32.append(state['exp_avg_sq'])
-
-            # Unscale fp32 grads and check for inf/nan
-            if dtype == torch.float16:
-                found_inf = torch.cuda.FloatTensor([0.0])
-                inv_scale = torch.cuda.FloatTensor([self.inv_scale])
-                torch._amp_foreach_non_finite_check_and_unscale_(g_32, found_inf, inv_scale)
-
-                group['found_inf'] = (found_inf.item() > 0)
-                if group['found_inf']:
-                    return loss
-
-            # assume same step across group now to simplify things
-            # per parameter step can be easily support by making it tensor, or pass list into kernel
-            if 'step' in group:
-                group['step'] += 1
-            else:
-                group['step'] = 1
 
             # Parameter update
             if len(g_32) > 0:
@@ -186,17 +198,16 @@ class SpiralGPUAdam(torch.optim.Optimizer):
         if not self.adam_w_mode:
             raise RuntimeError("SpiralGPUAdam only supports rollback for adam_w_mode.")
 
+        # if found_inf is True, skip rollback
+        if self.half_precision and self.found_inf:
+            return
+
         for group in self.param_groups:
             if len(group['params']) == 0:
                 continue
             dtype = group['params'][0].dtype
             bias_correction = 1 if group['bias_correction'] else 0
             beta1, beta2 = group['betas']
-
-            # if found_inf is True, skip rollback
-            if dtype == torch.float16:
-                if group['found_inf']:
-                    return
 
             # create lists for multi-tensor apply
             p_16 = []
@@ -240,12 +251,7 @@ class SpiralGPUAdam(torch.optim.Optimizer):
             self.step_event = None
 
         if found_inf is not None:
-            flag = 0
-            for group in self.param_groups:
-                if group['found_inf']:
-                    flag = 1
-                    break
-            found_inf.fill_(flag)
+            found_inf.fill_(1.0 if self.found_inf else 0.0)
 
 
 def multi_tensor_rollback_adamw(

--- a/megatron/spiral/optimizer/optimizer.py
+++ b/megatron/spiral/optimizer/optimizer.py
@@ -11,23 +11,10 @@ class SpiralFloat16Optimizer(MixedPrecisionOptimizer):
 
     @torch.no_grad()
     def step(self, args, timers):
-        if type(self.optimizer) == SpiralCPUAdam:
-            return self.optimizer.step()
-        else:
-            result = self.optimizer.step()
-            self.found_inf.fill_(0.0 if result else 1.0)
-            self.step_event = torch.cuda.Event()
-            self.step_event.record()
-            return result
+        return self.optimizer.step()
 
     def sync(self, found_inf=None):
-        if type(self.optimizer) == SpiralCPUAdam:
-            self.optimizer.sync(found_inf)
-        else:
-            if self.step_event is not None:
-                self.step_event.synchronize()
-                self.step_event = None
-            found_inf.data = self.found_inf.to(device = found_inf.device, non_blocking=False)
+        self.optimizer.sync(found_inf)
 
     @torch.no_grad()
     def rollback(self, sync=False):

--- a/megatron/spiral/optimizer/optimizer.py
+++ b/megatron/spiral/optimizer/optimizer.py
@@ -1,59 +1,21 @@
 import torch
 
 from megatron.core import tensor_parallel
-from megatron.optimizer.optimizer import Float16OptimizerWithFloat16Params, FP32Optimizer
+from megatron.optimizer.optimizer import MixedPrecisionOptimizer, Float16OptimizerWithFloat16Params, FP32Optimizer
+from megatron.optimizer.optimizer import _zero_grad_group_helper
 from megatron.spiral.optimizer.cpu_adam import SpiralCPUAdam
-from megatron.spiral.initialize import get_thunder_cuda_manager
 from megatron.spiral.utils import is_spiral_param
 
 
-class SpiralFloat16Optimizer(Float16OptimizerWithFloat16Params):
-    def __init__(self, optimizer, clip_grad, log_num_zeros_in_grad,
-                 params_have_main_grad, use_contiguous_buffers_in_local_ddp,
-                 fp16, bf16, params_dtype, grad_scaler, models):
-
-        for group in optimizer.param_groups:
-            for p in group["params"]:
-                if is_spiral_param(p):
-                    p.fetch(non_blocking=False)
-
-        super().__init__(
-            optimizer, clip_grad, log_num_zeros_in_grad,
-            params_have_main_grad, use_contiguous_buffers_in_local_ddp,
-            fp16, bf16, params_dtype, grad_scaler, models)
-
-        for group in self.float16_groups:
-            for p in group:
-                if is_spiral_param(p):
-                    p.free()
-
-        # dummy flag for temp
-        self.use_global_grad_scaler = True
-
-    def _unscale_main_grads_and_check_for_nan(self):
-
-        # Collect main grads.
-        main_grads = self._collect_main_grad_data_for_unscaling()
-
-        # Reset found inf.
-        self.found_inf.fill_(0.0)
-
-        # Unscale and set found inf/nan
-        # TODO: need to use inv_scale of SpiralStageOptimizer
-        torch._amp_foreach_non_finite_check_and_unscale_(
-            main_grads, self.found_inf, self.grad_scaler.inv_scale)
-
-        # Check for nan.
-        found_inf_flag = (self.found_inf.item() > 0)
-
-        return found_inf_flag
+class SpiralFloat16Optimizer(MixedPrecisionOptimizer):
 
     @torch.no_grad()
     def step(self, args, timers):
         if type(self.optimizer) == SpiralCPUAdam:
             return self.optimizer.step()
         else:
-            result = super().step(args, timers)
+            result = self.optimizer.step()
+            self.found_inf.fill_(0.0 if result else 1.0)
             self.step_event = torch.cuda.Event()
             self.step_event.record()
             return result
@@ -62,29 +24,37 @@ class SpiralFloat16Optimizer(Float16OptimizerWithFloat16Params):
         if type(self.optimizer) == SpiralCPUAdam:
             self.optimizer.sync(found_inf)
         else:
-            found_inf.data = self.found_inf.to(device = found_inf.device, non_blocking=False)
             if self.step_event is not None:
                 self.step_event.synchronize()
                 self.step_event = None
+            found_inf.data = self.found_inf.to(device = found_inf.device, non_blocking=False)
 
     @torch.no_grad()
     def rollback(self, sync=False):
         if type(self.optimizer) == SpiralCPUAdam:
             self.optimizer.rollback(sync)
         else:
-            if self.found_inf.item() == 0:
-                for group in self.float16_groups:
-                    for p in group:
-                        if is_spiral_param(p):
-                            p.fetch(non_blocking=not sync)
+            for group in self.optimizer.param_groups:
+                for p in group['params']:
+                    if is_spiral_param(p):
+                        p.fetch(non_blocking=not sync)
 
-                self.optimizer.rollback()
-                self._copy_main_params_to_model_params()
+            self.optimizer.rollback()
 
-                for group in self.float16_groups:
-                    for p in group:
-                        if is_spiral_param(p):
-                            p.offload(non_blocking=not sync)
+            for group in self.optimizer.param_groups:
+                for p in group['params']:
+                    if is_spiral_param(p):
+                        p.offload(non_blocking=not sync)
+
+    def zero_grad(self, set_to_none=True):
+        for group in self.optimizer.param_groups:
+            _zero_grad_group_helper(group['params'], set_to_none)
+    
+    def state_dict(self):
+        return self.optimizer.state_dict()
+
+    def load_state_dict(self, state_dict):
+        self.optimizer.load_state_dict(state_dict)
 
 
 class SpiralFP32Optimizer(FP32Optimizer):
@@ -93,7 +63,7 @@ class SpiralFP32Optimizer(FP32Optimizer):
         if type(self.optimizer) == SpiralCPUAdam:
             return self.optimizer.step()
         else:
-            result = super().step(args, timers)
+            result = self.optimizer.step()
             self.step_event = torch.cuda.Event()
             self.step_event.record()
             return result

--- a/megatron/spiral/optimizer/optimizer.py
+++ b/megatron/spiral/optimizer/optimizer.py
@@ -11,7 +11,7 @@ class SpiralFloat16Optimizer(MixedPrecisionOptimizer):
 
     @torch.no_grad()
     def step(self, args, timers):
-        return self.optimizer.step()
+        self.optimizer.step()
 
     def sync(self, found_inf=None):
         self.optimizer.sync(found_inf)
@@ -47,21 +47,10 @@ class SpiralFloat16Optimizer(MixedPrecisionOptimizer):
 class SpiralFP32Optimizer(FP32Optimizer):
     @torch.no_grad()
     def step(self, args, timers):
-        if type(self.optimizer) == SpiralCPUAdam:
-            return self.optimizer.step()
-        else:
-            result = self.optimizer.step()
-            self.step_event = torch.cuda.Event()
-            self.step_event.record()
-            return result
+        self.optimizer.step()
 
     def sync(self, found_inf=None):
-        if type(self.optimizer) == SpiralCPUAdam:
-            self.optimizer.sync(found_inf)
-        else:
-            if self.step_event is not None:
-                self.step_event.synchronize()
-                self.step_event = None
+        self.optimizer.sync()
 
     def rollback(self, sync=False):
         # No need to rollback for fp32 param

--- a/megatron/spiral/optimizer/stage_optimizer.py
+++ b/megatron/spiral/optimizer/stage_optimizer.py
@@ -72,10 +72,9 @@ class SpiralStageOptimizer:
         if event_query != None:
             event_long = get_thunder_cuda_manager().get_event(event_query).cuda_event
         
-        if self.is_cpu_optimizer(idx):
-            inner_opt = self.optimizer_list[idx].optimizer
-            inner_opt.inv_scale = self.inv_scale_val
-            inner_opt.ev_long = event_long
+        inner_opt = self.optimizer_list[idx].optimizer
+        inner_opt.inv_scale = self.inv_scale_val
+        inner_opt.ev_long = event_long
 
         self.optimizer_list[idx].step(args, timers)
 


### PR DESCRIPTION
### Feature
- As-is: `SpiralGPUAdam` inherit `Float16OptimizerWithFloat16Params` class to handle mixed precision
- To-be: Make `SpiralGPUAdam` handle mixed precision logic in the step/rollback method like `SpiralCPUAdam`

###  Note
Depending on the command option, optimizers are defined differently. (reference: `megatron/optimizer/__init__.py`)
There are three main types of optimizers:
- **SpiralStageOptimizer**
  - stage optimizer가 활성화 될 때 optimizer list를 묶어서 관리하는 class
- **MegatronOptimizer**
  - optimizer 실행 전후로 megatron feature를 지원하는 로직을 추가한 wrapper class
  - Megatron인 경우, parameter dtype에 따라 `Float16OptimizerWithFloat16Params` `FP32Optimizer`를 사용
  - stage optimizer가 활성화 된 경우, 위의 class를 상속하는 `SpiralFloat16Optimizer` `SpiralFP32Optimizer`를 사용하도록 함
  - stage optimizer가 비활성화 된 경우, `DeepSpeedFloat16Optimizer`를 사용하도록 함
- **Base optimizer**
  - 실제 parameter update를 수행하는 real optimizer class
  - Megatron의 경우, apex `FusedAdam` 사용
  - stage optimizer가 활성화된 경우, `SpiralCPUAdam` or `SpiralGPUAdam` 사용
  - stage optimizer가 비활성화된 경우, `DeepSpeedCPUAdam` 사용

```md
- FP16 megatron optimizer : Float16OptimizerWithFloat16Params(FusedAdam)
- FP32 megatron optimizer : FP32Optimizer(FusedAdam)
- FP16 no staged optimizer : DeepSpeedFloat16Optimizer(DeepSpeedCPUAdam)
- FP32 no staged optimizer : FP32Optimizer(DeepSpeedCPUAdam)
- FP16 staged optimizer : SpiralStageOptimizer(...SpiralFloat16Optimizer(SpiralCPUAdam | SpiralGPUAdam))
- FP16 staged optimizer : SpiralStageOptimizer(...SpiralFP32Optimizer(SpiralCPUAdam | SpiralGPUAdam))
```
> NOTE: no stage optimizer인 경우에도 spiral optimizer를 사용할 수 있으나, deepspeed optimizer를 비교군으로 두고 실험하기 위해 구현체를 별도로 둠