### PR TITLE
Fetch and offload optimizer state in SpiralGPUChunkedAdam

### DIFF
--- a/examples/asplos25/config.sh
+++ b/examples/asplos25/config.sh
@@ -81,10 +81,14 @@ SPIRAL_SHMEM_HEADER_SIZE=$(( 1 * 2**30 ))
 SPIRAL_DEBUG_BACKEND=NO
 
 SPIRAL_HETERO_OPTIMIZER=NO
+SPIRAL_OFFLOAD_OPTIMIZER=NO
 if [[ "$OPTIMIZER" == *"stage"* ]]; then
     SPIRAL_STAGE_OPTIMIZER=YES
     if [[ "$OPTIMIZER" == *"hetero"* ]]; then
         SPIRAL_HETERO_OPTIMIZER=YES
+    fi
+    if [[ "$OPTIMIZER" == *"offload"* ]]; then
+        SPIRAL_OFFLOAD_OPTIMIZER=YES
     fi
 else
     SPIRAL_STAGE_OPTIMIZER=NO

--- a/examples/asplos25/extra_args/mobius.sh
+++ b/examples/asplos25/extra_args/mobius.sh
@@ -25,3 +25,7 @@ fi
 if [ ${SPIRAL_HETERO_OPTIMIZER} == "YES" ]; then
     EXTRA_ARGS+=" --spiral-heterogeneous-optimizer"
 fi
+
+if [ ${SPIRAL_OFFLOAD_OPTIMIZER} == "YES" ]; then
+    EXTRA_ARGS+=" --spiral-offload-optimizer"
+fi

--- a/examples/asplos25/extra_args/spiral.sh
+++ b/examples/asplos25/extra_args/spiral.sh
@@ -29,6 +29,10 @@ if [ ${SPIRAL_HETERO_OPTIMIZER} == "YES" ]; then
     EXTRA_ARGS+=" --spiral-heterogeneous-optimizer"
 fi
 
+if [ ${SPIRAL_OFFLOAD_OPTIMIZER} == "YES" ]; then
+    EXTRA_ARGS+=" --spiral-offload-optimizer"
+fi
+
 if [ ${SPIRAL_CROSS_MAPPING} == "YES" ]; then
     EXTRA_ARGS+=" --spiral-cross-mapping"
 fi

--- a/megatron/arguments.py
+++ b/megatron/arguments.py
@@ -446,6 +446,8 @@ def validate_args(args, defaults={}):
                 "SpiralPipe currently does not support distributed optimizer")
         if args.spiral_heterogeneous_optimizer:
             assert args.spiral_stage_optimizer, "spiral-heterogeneous-optimizer should be enabled with spiral-stage-optimizer"
+        if args.spiral_offload_optimizer:
+            assert args.spiral_heterogeneous_optimizer, "spiral-offload-optimizer should be enabled with spiral-heterogeneous-optimizer"
         if (args.spiral_remap and args.spiral_1f1b) or (args.spiral_remap and args.spiral_mobius) or (args.spiral_1f1b and args.spiral_mobius):
             raise RuntimeError(
                 "SpiralPipe does not support remapping/1f1b/mobius together")
@@ -1128,6 +1130,8 @@ def _add_distributed_args(parser):
     group.add_argument('--spiral-heterogeneous-optimizer', action='store_true',
                         help='Enable cpu-gpu heterogeneous optimizer per each stage. '
                         'Use gpu optimizer for the first stage and cpu optimizer for the others')
+    group.add_argument('--spiral-offload-optimizer', action='store_true',
+                        help='Enable offload optimizer state per chunked parameter in gpu heterogeneous optimizer.')
     group.add_argument('--spiral-debug-backend', action='store_true',
                        help='Enable SpiralPipe backend logging')
     group.add_argument('--spiral-cross-mapping', action='store_true',

--- a/megatron/optimizer/__init__.py
+++ b/megatron/optimizer/__init__.py
@@ -98,6 +98,14 @@ def get_megatron_optimizer(model,
                            no_weight_decay_cond=None,
                            scale_lr_cond=None,
                            lr_mult=1.0):
+    """
+    - FP16 megatron optimizer : Float16OptimizerWithFloat16Params(FusedAdam)
+    - FP32 megatron optimizer : FP32Optimizer(FusedAdam)
+    - FP16 no staged optimizer : DeepSpeedFloat16Optimizer(DeepSpeedCPUAdam)
+    - FP32 no staged optimizer : FP32Optimizer(DeepSpeedCPUAdam)
+    - FP16 staged optimizer : SpiralStageOptimizer(...SpiralFloat16Optimizer(SpiralCPUAdam | SpiralGPUAdam | SpiralGPUChunkedAdam))
+    - FP16 staged optimizer : SpiralStageOptimizer(...SpiralFP32Optimizer(SpiralCPUAdam | SpiralGPUAdam | SpiralGPUChunkedAdam))
+    """
     args = get_args()
 
     # Determine whether the params have main-grad field.
@@ -152,8 +160,12 @@ def get_megatron_optimizer(model,
             # NOTE (SpiralPipe) Spiral stage optimizer uses SpiralCPUAdam, which overlaps weight update with upstream bwd stage computation.
             # If --spiral-heterogeneous-optimizer is enabled, apply gpu optimizer to first stage.
             if args.spiral_heterogeneous_optimizer and _unwrapped_model.spiral_backward_stage_id == 0:
-                from megatron.spiral.optimizer.gpu_adam import SpiralGPUAdam
-                inner_opt_ty = SpiralGPUAdam
+                if args.spiral_offload_optimizer:
+                    from megatron.spiral.optimizer.gpu_chunked_adam import SpiralGPUChunkedAdam
+                    inner_opt_ty = SpiralGPUChunkedAdam
+                else:
+                    from megatron.spiral.optimizer.gpu_adam import SpiralGPUAdam
+                    inner_opt_ty = SpiralGPUAdam
             else:
                 from megatron.spiral.optimizer.cpu_adam import SpiralCPUAdam
                 inner_opt_ty = SpiralCPUAdam

--- a/megatron/spiral/optimizer/gpu_adam.py
+++ b/megatron/spiral/optimizer/gpu_adam.py
@@ -110,7 +110,8 @@ class SpiralGPUAdam(torch.optim.Optimizer):
         if len(cpu_state) == 0:
             cpu_state['exp_avg'] = torch.empty(shape, device=self.remote_device, dtype=torch.float32, pin_memory=True)
             cpu_state['exp_avg_sq'] = torch.empty(shape, device=self.remote_device, dtype=torch.float32, pin_memory=True)
-            cpu_state['fp32_param'] = torch.empty(shape, device=self.remote_device, dtype=torch.float32, pin_memory=True)
+            if self.half_precision:
+                cpu_state['fp32_param'] = torch.empty(shape, device=self.remote_device, dtype=torch.float32, pin_memory=True)
 
     @nvtx.annotate("offload_state", color="pink")
     def offload_state(self, idx):
@@ -118,14 +119,16 @@ class SpiralGPUAdam(torch.optim.Optimizer):
         cpu_state = self.cpu_state[idx]
         cpu_state['exp_avg'].copy_(gpu_state['exp_avg'].data, non_blocking=True)
         cpu_state['exp_avg_sq'].copy_(gpu_state['exp_avg_sq'].data, non_blocking=True)
-        cpu_state['fp32_param'].copy_(gpu_state['fp32_param'].data, non_blocking=True)
+        if self.half_precision:
+            cpu_state['fp32_param'].copy_(gpu_state['fp32_param'].data, non_blocking=True)
 
     @nvtx.annotate("free_state", color="purple")
     def free_state(self, idx):
         gpu_state = self.gpu_state[idx]
         gpu_state['exp_avg'] = None
         gpu_state['exp_avg_sq'] = None
-        gpu_state['fp32_param'] = None
+        if self.half_precision:
+            gpu_state['fp32_param'] = None
 
     @nvtx.annotate("fetch_state", color="green")
     def fetch_state(self, idx):
@@ -133,7 +136,8 @@ class SpiralGPUAdam(torch.optim.Optimizer):
         cpu_state = self.cpu_state[idx]
         gpu_state['exp_avg'] = cpu_state['exp_avg'].to(device=self.local_device, non_blocking=True)
         gpu_state['exp_avg_sq'] = cpu_state['exp_avg_sq'].to(device=self.local_device, non_blocking=True)
-        gpu_state['fp32_param'] = cpu_state['fp32_param'].to(device=self.local_device, non_blocking=True)
+        if self.half_precision:
+            gpu_state['fp32_param'] = cpu_state['fp32_param'].to(device=self.local_device, non_blocking=True)
 
     def step(self, closure=None, grads=None, output_params=None, scale=None, grad_norms=None, grad_scaler=None):
         """Performs a single optimization step.
@@ -188,7 +192,6 @@ class SpiralGPUAdam(torch.optim.Optimizer):
         for group in self.param_groups:
             if group['chunked_param_num'] == 0:
                 continue
-            dtype = group['params'][0].dtype
             bias_correction = 1 if group['bias_correction'] else 0
             beta1, beta2 = group['betas']
 
@@ -227,18 +230,18 @@ class SpiralGPUAdam(torch.optim.Optimizer):
                         # Exponential moving average of squared gradient values
                         gpu_state['exp_avg_sq'] = torch.zeros_like(p.data).float()
                         # Copy fp16 param to fp32 param
-                        if dtype == torch.float16 or dtype == torch.bfloat16:
+                        if self.half_precision:
                             gpu_state['fp32_param'] = p.detach().clone().float()
-                        else:
-                            gpu_state['fp32_param'] = p
 
                         self.init_cpu_state(chunked_idx, p.data.shape)
 
-                    if dtype == torch.float16 or dtype == torch.bfloat16:
+                    if self.half_precision:
                         p_16.append(p.data)
+                        p_32.append(gpu_state['fp32_param'].data)
+                    else:
+                        p_32.append(p.data)
 
                     g_32.append(g.data)
-                    p_32.append(gpu_state['fp32_param'].data)
                     m_32.append(gpu_state['exp_avg'])
                     v_32.append(gpu_state['exp_avg_sq'])
 
@@ -259,7 +262,7 @@ class SpiralGPUAdam(torch.optim.Optimizer):
                             group['weight_decay'])
 
                     # Copy fp32 params to fp16 params
-                    if dtype == torch.float16 or dtype == torch.bfloat16:
+                    if self.half_precision:
                         # Scaling with factor `1.0` is equivalent to copy.
                         multi_tensor_applier(self.multi_tensor_scale,
                                             self._dummy_overflow_buf,
@@ -311,7 +314,6 @@ class SpiralGPUAdam(torch.optim.Optimizer):
             assert 'chunked_param_num' in group, "Rollback should be call after run optimizer.step"
             if group['chunked_param_num'] == 0:
                 continue
-            dtype = group['params'][0].dtype
             bias_correction = 1 if group['bias_correction'] else 0
             beta1, beta2 = group['betas']
 
@@ -335,11 +337,13 @@ class SpiralGPUAdam(torch.optim.Optimizer):
                     p_16 = []
                     g_32, p_32, m_32, v_32 = [], [], [], []
 
-                    if dtype == torch.float16 or dtype == torch.bfloat16:
+                    if self.half_precision:
                         p_16.append(p.data)
+                        p_32.append(gpu_state['fp32_param'].data)
+                    else:
+                        p_32.append(p.data)
 
                     g_32.append(g.data)
-                    p_32.append(gpu_state['fp32_param'].data)
                     m_32.append(gpu_state['exp_avg'])
                     v_32.append(gpu_state['exp_avg_sq'])
 
@@ -358,7 +362,7 @@ class SpiralGPUAdam(torch.optim.Optimizer):
                         group['weight_decay'])
 
                     # Copy fp32 params to fp16 params
-                    if dtype == torch.float16 or dtype == torch.bfloat16:
+                    if self.half_precision:
                         # Scaling with factor `1.0` is equivalent to copy.
                         multi_tensor_applier(self.multi_tensor_scale,
                                             self._dummy_overflow_buf,

--- a/megatron/spiral/optimizer/gpu_adam.py
+++ b/megatron/spiral/optimizer/gpu_adam.py
@@ -111,7 +111,6 @@ class SpiralGPUAdam(torch.optim.Optimizer):
             cpu_state['exp_avg'] = torch.empty(shape, device=self.remote_device, dtype=torch.float32, pin_memory=True)
             cpu_state['exp_avg_sq'] = torch.empty(shape, device=self.remote_device, dtype=torch.float32, pin_memory=True)
             cpu_state['fp32_param'] = torch.empty(shape, device=self.remote_device, dtype=torch.float32, pin_memory=True)
-            cpu_state['fp32_grad'] = torch.empty(shape, device=self.remote_device, dtype=torch.float32, pin_memory=True)
 
     @nvtx.annotate("offload_state", color="pink")
     def offload_state(self, idx):
@@ -120,7 +119,6 @@ class SpiralGPUAdam(torch.optim.Optimizer):
         cpu_state['exp_avg'].copy_(gpu_state['exp_avg'].data, non_blocking=True)
         cpu_state['exp_avg_sq'].copy_(gpu_state['exp_avg_sq'].data, non_blocking=True)
         cpu_state['fp32_param'].copy_(gpu_state['fp32_param'].data, non_blocking=True)
-        cpu_state['fp32_grad'].copy_(gpu_state['fp32_grad'].data, non_blocking=True)
 
     @nvtx.annotate("free_state", color="purple")
     def free_state(self, idx):
@@ -128,19 +126,14 @@ class SpiralGPUAdam(torch.optim.Optimizer):
         gpu_state['exp_avg'] = None
         gpu_state['exp_avg_sq'] = None
         gpu_state['fp32_param'] = None
-        gpu_state['fp32_grad'] = None
 
     @nvtx.annotate("fetch_state", color="green")
-    def fetch_state(self, idx, grad_temp=False):
+    def fetch_state(self, idx):
         gpu_state = self.gpu_state[idx]
         cpu_state = self.cpu_state[idx]
         gpu_state['exp_avg'] = cpu_state['exp_avg'].to(device=self.local_device, non_blocking=True)
         gpu_state['exp_avg_sq'] = cpu_state['exp_avg_sq'].to(device=self.local_device, non_blocking=True)
         gpu_state['fp32_param'] = cpu_state['fp32_param'].to(device=self.local_device, non_blocking=True)
-
-        # TODO: remove grad_temp
-        if grad_temp:
-            gpu_state['fp32_grad'] = cpu_state['fp32_grad'].to(device=self.local_device, non_blocking=True)
 
     def step(self, closure=None, grads=None, output_params=None, scale=None, grad_norms=None, grad_scaler=None):
         """Performs a single optimization step.
@@ -241,13 +234,10 @@ class SpiralGPUAdam(torch.optim.Optimizer):
 
                         self.init_cpu_state(chunked_idx, p.data.shape)
 
-                    gpu_state['fp32_grad'] = g
-                    g = None
-
                     if dtype == torch.float16 or dtype == torch.bfloat16:
                         p_16.append(p.data)
 
-                    g_32.append(gpu_state['fp32_grad'].data)
+                    g_32.append(g.data)
                     p_32.append(gpu_state['fp32_param'].data)
                     m_32.append(gpu_state['exp_avg'])
                     v_32.append(gpu_state['exp_avg_sq'])
@@ -290,6 +280,9 @@ class SpiralGPUAdam(torch.optim.Optimizer):
                     event.record()
                     free_events.append(event)
 
+        self.step_event = torch.cuda.Event()
+        self.step_event.record()
+
         # Free optimizer state
         chunked_idx = -1
         for group in self.param_groups:
@@ -299,8 +292,6 @@ class SpiralGPUAdam(torch.optim.Optimizer):
                     free_events.pop(0).synchronize()
                 self.free_state(chunked_idx)
 
-        self.step_event = torch.cuda.Event()
-        self.step_event.record()
         return loss
 
     def rollback(self):
@@ -311,52 +302,93 @@ class SpiralGPUAdam(torch.optim.Optimizer):
         if self.half_precision and self.found_inf:
             return
 
+        prefetch_events = []
+        compute_events = []
+        free_events = []
+        chunked_idx = -1
+
         for group in self.param_groups:
-            if len(group['params']) == 0:
+            assert 'chunked_param_num' in group, "Rollback should be call after run optimizer.step"
+            if group['chunked_param_num'] == 0:
                 continue
             dtype = group['params'][0].dtype
             bias_correction = 1 if group['bias_correction'] else 0
             beta1, beta2 = group['betas']
 
-            # create lists for multi-tensor apply
-            p_16 = []
-            g_32, p_32, m_32, v_32 = [], [], [], []
+            for i in range(group['chunked_param_num']):
+                chunked_idx += 1
+                gpu_state = self.gpu_state[chunked_idx]
+                assert len(gpu_state) != 0, "Rollback should be call after run optimizer.step"
+                p = group['chunked_params'][i]
+                g = group['chunked_grads'][i]
 
-            for p in group['params']:
-                state = self.state[p]
-                assert len(state) != 0, "Rollback should be call after run optimizer.step"
-                self.fetch_state(p, grad_temp=True)
+                # Fetch optimizer state
+                with torch.cuda.stream(get_thunder_cuda_manager().Stream("prefetch")):
+                    self.fetch_state(chunked_idx)
+                    event = torch.cuda.Event()
+                    event.record()
+                    prefetch_events.append(event)
 
-                if dtype == torch.float16 or dtype == torch.bfloat16:
-                    p_16.append(p.data)
+                # Parameter update
+                with torch.cuda.stream(get_thunder_cuda_manager().Stream("compute")):
+                    # create lists for multi-tensor apply
+                    p_16 = []
+                    g_32, p_32, m_32, v_32 = [], [], [], []
 
-                g_32.append(state['fp32_grad'].data)
-                p_32.append(state['fp32_param'].data)
-                m_32.append(state['exp_avg'])
-                v_32.append(state['exp_avg_sq'])
+                    if dtype == torch.float16 or dtype == torch.bfloat16:
+                        p_16.append(p.data)
 
-            if len(g_32) > 0:
-                multi_tensor_rollback_adamw(
-                    g_32, p_32, m_32, v_32,
-                    group['lr'],
-                    beta1,
-                    beta2,
-                    group['eps'],
-                    group['step'],
-                    bias_correction,
-                    group['weight_decay'])
+                    g_32.append(g.data)
+                    p_32.append(gpu_state['fp32_param'].data)
+                    m_32.append(gpu_state['exp_avg'])
+                    v_32.append(gpu_state['exp_avg_sq'])
+
+                    if len(prefetch_events) > 0:
+                        prefetch_events.pop(0).wait()
+
+                    # Parameter update
+                    multi_tensor_rollback_adamw(
+                        g_32, p_32, m_32, v_32,
+                        group['lr'],
+                        beta1,
+                        beta2,
+                        group['eps'],
+                        group['step'],
+                        bias_correction,
+                        group['weight_decay'])
+
+                    # Copy fp32 params to fp16 params
+                    if dtype == torch.float16 or dtype == torch.bfloat16:
+                        # Scaling with factor `1.0` is equivalent to copy.
+                        multi_tensor_applier(self.multi_tensor_scale,
+                                            self._dummy_overflow_buf,
+                                            [p_32, p_16],
+                                            1.0)
+
+                    event = torch.cuda.Event()
+                    event.record()
+                    compute_events.append(event)
+                
+                # Offload optimizer state
+                with torch.cuda.stream(get_thunder_cuda_manager().Stream("offload")):
+                    if len(compute_events) > 0:
+                            compute_events.pop(0).wait()
+                    self.offload_state(chunked_idx)
+
+                    event = torch.cuda.Event()
+                    event.record()
+                    free_events.append(event)
+
             group['step'] -= 1
 
-            # Copy fp32 params to fp16 params
-            if dtype == torch.float16 or dtype == torch.bfloat16:
-                # Scaling with factor `1.0` is equivalent to copy.
-                multi_tensor_applier(self.multi_tensor_scale,
-                                     self._dummy_overflow_buf,
-                                     [p_32, p_16],
-                                     1.0)
-            
-            for p in group['params']:
-                self.offload_state(p)
+        # Free optimizer state
+        chunked_idx = -1
+        for group in self.param_groups:
+            for i in range(group['chunked_param_num']):
+                chunked_idx += 1
+                if len(free_events) > 0:
+                    free_events.pop(0).synchronize()
+                self.free_state(chunked_idx)
 
     def sync(self, found_inf=None):
         if self.step_event is not None:

--- a/megatron/spiral/optimizer/gpu_adam.py
+++ b/megatron/spiral/optimizer/gpu_adam.py
@@ -4,8 +4,12 @@
 # with some modifications.
 
 import torch
+import nvtx
 from apex.multi_tensor_apply import multi_tensor_applier
+from collections import defaultdict
+
 from megatron import get_args
+from megatron.spiral.initialize import get_thunder_cuda_manager
 
 
 class SpiralGPUAdam(torch.optim.Optimizer):
@@ -58,6 +62,11 @@ class SpiralGPUAdam(torch.optim.Optimizer):
         self.params_have_main_grad = True
         self.step_event = None
 
+        self.local_device = torch.cuda.current_device()
+        self.remote_device = torch.device("cpu")
+        self.cpu_state = defaultdict(dict)
+        self.numel_threshold = get_args().hidden_size * get_args().hidden_size
+
         if multi_tensor_applier.available:
             import amp_C
             # Skip buffer
@@ -94,6 +103,42 @@ class SpiralGPUAdam(torch.optim.Optimizer):
 
         return found_inf.item() > 0
 
+    def init_cpu_state(self, p):
+        cpu_state = self.cpu_state[p]
+        if len(cpu_state) == 0:
+            cpu_state['exp_avg'] = torch.empty(p.data.shape, device=self.remote_device, dtype=torch.float32, pin_memory=True)
+            cpu_state['exp_avg_sq'] = torch.empty(p.data.shape, device=self.remote_device, dtype=torch.float32, pin_memory=True)
+            cpu_state['fp32_param'] = torch.empty(p.data.shape, device=self.remote_device, dtype=torch.float32, pin_memory=True)
+            cpu_state['fp32_grad'] = torch.empty(p.data.shape, device=self.remote_device, dtype=torch.float32, pin_memory=True)
+
+    @nvtx.annotate("offload_state", color="pink")
+    def offload_state(self, p):
+        state = self.state[p]
+        cpu_state = self.cpu_state[p]
+        cpu_state['exp_avg'].copy_(state['exp_avg'].data, non_blocking=True)
+        cpu_state['exp_avg_sq'].copy_(state['exp_avg_sq'].data, non_blocking=True)
+        cpu_state['fp32_param'].copy_(state['fp32_param'].data, non_blocking=True)
+        cpu_state['fp32_grad'].copy_(state['fp32_grad'].data, non_blocking=True)
+
+    @nvtx.annotate("free_state", color="purple")
+    def free_state(self, p):
+        state = self.state[p]
+        state['exp_avg'] = None
+        state['exp_avg_sq'] = None
+        state['fp32_param'] = None
+        state['fp32_grad'] = None
+
+    @nvtx.annotate("fetch_state", color="green")
+    def fetch_state(self, p, grad_temp=False):
+        state = self.state[p]
+        cpu_state = self.cpu_state[p]
+        state['exp_avg'] = cpu_state['exp_avg'].to(device=self.local_device, non_blocking=True)
+        state['exp_avg_sq'] = cpu_state['exp_avg_sq'].to(device=self.local_device, non_blocking=True)
+        state['fp32_param'] = cpu_state['fp32_param'].to(device=self.local_device, non_blocking=True)
+
+        if grad_temp:
+            state['fp32_grad'] = cpu_state['fp32_grad'].to(device=self.local_device, non_blocking=True)
+
     def step(self, closure=None, grads=None, output_params=None, scale=None, grad_norms=None, grad_scaler=None):
         """Performs a single optimization step.
 
@@ -115,83 +160,118 @@ class SpiralGPUAdam(torch.optim.Optimizer):
             if self.found_inf:
                 return loss
 
-        for group in self.param_groups:
-            if len(group['params']) == 0:
-                continue
-            dtype = group['params'][0].dtype
-            bias_correction = 1 if group['bias_correction'] else 0
-            beta1, beta2 = group['betas']
+        prefetch_events = []
+        compute_events = []
 
-            # assume same step across group now to simplify things
-            # per parameter step can be easily support by making it tensor, or pass list into kernel
-            if 'step' in group:
-                group['step'] += 1
-            else:
-                group['step'] = 1
+        # Fetch optimizer state
+        with torch.cuda.stream(get_thunder_cuda_manager().Stream("prefetch")):
+            for group in self.param_groups:
+                for i, p in enumerate(group['params']):
+                    state = self.state[p]
+                    if not len(state) == 0:
+                        self.fetch_state(p)
+                        event = torch.cuda.Event()
+                        event.record()
+                        prefetch_events.append(event)
 
-            # create lists for multi-tensor apply
-            p_16 = []
-            g_32, p_32, m_32, v_32 = [], [], [], []
-
-            for p in group['params']:
-                if self.params_have_main_grad and hasattr(p, 'main_grad'):
-                    grad = p.main_grad
-                else:
-                    grad = p.grad
-
-                if grad is None:
+        # Parameter update
+        with torch.cuda.stream(get_thunder_cuda_manager().Stream("compute")):
+            for group in self.param_groups:
+                if len(group['params']) == 0:
                     continue
-                if grad.data.is_sparse:
-                    raise RuntimeError('SpiralGPUAdam does not support sparse gradients, please consider SparseAdam instead')
+                dtype = group['params'][0].dtype
+                bias_correction = 1 if group['bias_correction'] else 0
+                beta1, beta2 = group['betas']
 
-                state = self.state[p]
-                # State initialization
-                if len(state) == 0:
-                    # Exponential moving average of gradient values
-                    state['exp_avg'] = torch.zeros_like(p.data).float()
-                    # Exponential moving average of squared gradient values
-                    state['exp_avg_sq'] = torch.zeros_like(p.data).float()
-                    # Copy fp16 param to fp32 param
-                    if dtype == torch.float16 or dtype == torch.bfloat16:
-                        state['fp32_param'] = p.detach().clone().float()
+                # assume same step across group now to simplify things
+                # per parameter step can be easily support by making it tensor, or pass list into kernel
+                if 'step' in group:
+                    group['step'] += 1
+                else:
+                    group['step'] = 1
+
+                for i, p in enumerate(group['params']):
+                    # create lists for multi-tensor apply
+                    p_16 = []
+                    g_32, p_32, m_32, v_32 = [], [], [], []
+
+                    if self.params_have_main_grad and hasattr(p, 'main_grad'):
+                        grad = p.main_grad
                     else:
-                        state['fp32_param'] = p
-                
-                state['fp32_grad'] = grad
-                grad = None
+                        grad = p.grad
 
-                if dtype == torch.float16 or dtype == torch.bfloat16:
-                    p_16.append(p.data)
+                    if grad is None:
+                        continue
+                    if grad.data.is_sparse:
+                        raise RuntimeError('SpiralGPUAdam does not support sparse gradients, please consider SparseAdam instead')
 
-                g_32.append(state['fp32_grad'].data)
-                p_32.append(state['fp32_param'].data)
-                m_32.append(state['exp_avg'])
-                v_32.append(state['exp_avg_sq'])
+                    state = self.state[p]
+                    # State initialization
+                    if len(state) == 0:
+                        # Exponential moving average of gradient values
+                        state['exp_avg'] = torch.zeros_like(p.data).float()
+                        # Exponential moving average of squared gradient values
+                        state['exp_avg_sq'] = torch.zeros_like(p.data).float()
+                        # Copy fp16 param to fp32 param
+                        if dtype == torch.float16 or dtype == torch.bfloat16:
+                            state['fp32_param'] = p.detach().clone().float()
+                        else:
+                            state['fp32_param'] = p
+                    
+                        self.init_cpu_state(p)
 
-            # Parameter update
-            if len(g_32) > 0:
-                multi_tensor_applier(self.multi_tensor_adam,
-                        self._dummy_overflow_buf,
-                        [g_32, p_32, m_32, v_32],
-                        group['lr'],
-                        beta1,
-                        beta2,
-                        group['eps'],
-                        group['step'],
-                        self.adam_w_mode,
-                        bias_correction,
-                        group['weight_decay'])
+                    state['fp32_grad'] = grad
+                    grad = None
 
-            # Copy fp32 params to fp16 params
-            if dtype == torch.float16 or dtype == torch.bfloat16:
-                # Scaling with factor `1.0` is equivalent to copy.
-                multi_tensor_applier(self.multi_tensor_scale,
-                                     self._dummy_overflow_buf,
-                                     [p_32, p_16],
-                                     1.0)
+                    if dtype == torch.float16 or dtype == torch.bfloat16:
+                        p_16.append(p.data)
 
-        self.step_event = torch.cuda.Event()
-        self.step_event.record()
+                    g_32.append(state['fp32_grad'].data)
+                    p_32.append(state['fp32_param'].data)
+                    m_32.append(state['exp_avg'])
+                    v_32.append(state['exp_avg_sq'])
+
+                    if len(prefetch_events) > 0:
+                        prefetch_events.pop(0).wait()
+
+                    # Parameter update
+                    multi_tensor_applier(self.multi_tensor_adam,
+                            self._dummy_overflow_buf,
+                            [g_32, p_32, m_32, v_32],
+                            group['lr'],
+                            beta1,
+                            beta2,
+                            group['eps'],
+                            group['step'],
+                            self.adam_w_mode,
+                            bias_correction,
+                            group['weight_decay'])
+
+                    # Copy fp32 params to fp16 params
+                    if dtype == torch.float16 or dtype == torch.bfloat16:
+                        # Scaling with factor `1.0` is equivalent to copy.
+                        multi_tensor_applier(self.multi_tensor_scale,
+                                            self._dummy_overflow_buf,
+                                            [p_32, p_16],
+                                            1.0)
+
+                    event = torch.cuda.Event()
+                    event.record()
+                    compute_events.append(event)
+
+        # Offload optimizer state
+        with torch.cuda.stream(get_thunder_cuda_manager().Stream("offload")):
+            if len(compute_events) > 0:
+                    compute_events.pop(0).wait()
+            for group in self.param_groups:
+                for i, p in enumerate(group['params']):
+                    self.offload_state(p)
+                    if len(compute_events) > 0:
+                        compute_events.pop(0).wait()
+
+            self.step_event = torch.cuda.Event()
+            self.step_event.record()
+
         return loss
 
     def rollback(self):
@@ -216,6 +296,7 @@ class SpiralGPUAdam(torch.optim.Optimizer):
             for p in group['params']:
                 state = self.state[p]
                 assert len(state) != 0, "Rollback should be call after run optimizer.step"
+                self.fetch_state(p, grad_temp=True)
 
                 if dtype == torch.float16 or dtype == torch.bfloat16:
                     p_16.append(p.data)
@@ -244,6 +325,9 @@ class SpiralGPUAdam(torch.optim.Optimizer):
                                      self._dummy_overflow_buf,
                                      [p_32, p_16],
                                      1.0)
+            
+            for p in group['params']:
+                self.offload_state(p)
 
     def sync(self, found_inf=None):
         if self.step_event is not None:

--- a/megatron/spiral/optimizer/gpu_adam.py
+++ b/megatron/spiral/optimizer/gpu_adam.py
@@ -4,12 +4,8 @@
 # with some modifications.
 
 import torch
-import nvtx
 from apex.multi_tensor_apply import multi_tensor_applier
-from collections import defaultdict
-
 from megatron import get_args
-from megatron.spiral.initialize import get_thunder_cuda_manager
 
 
 class SpiralGPUAdam(torch.optim.Optimizer):
@@ -61,13 +57,6 @@ class SpiralGPUAdam(torch.optim.Optimizer):
         self.inv_scale = 0
         self.params_have_main_grad = True
         self.step_event = None
-        self.found_inf = False
-
-        self.local_device = torch.cuda.current_device()
-        self.remote_device = torch.device("cpu")
-        self.gpu_state = defaultdict(dict)
-        self.cpu_state = defaultdict(dict)
-        self.numel_threshold = get_args().hidden_size * get_args().hidden_size
 
         if multi_tensor_applier.available:
             import amp_C
@@ -105,40 +94,6 @@ class SpiralGPUAdam(torch.optim.Optimizer):
 
         return found_inf.item() > 0
 
-    def init_cpu_state(self, idx, shape):
-        cpu_state = self.cpu_state[idx]
-        if len(cpu_state) == 0:
-            cpu_state['exp_avg'] = torch.empty(shape, device=self.remote_device, dtype=torch.float32, pin_memory=True)
-            cpu_state['exp_avg_sq'] = torch.empty(shape, device=self.remote_device, dtype=torch.float32, pin_memory=True)
-            if self.half_precision:
-                cpu_state['fp32_param'] = torch.empty(shape, device=self.remote_device, dtype=torch.float32, pin_memory=True)
-
-    @nvtx.annotate("offload_state", color="pink")
-    def offload_state(self, idx):
-        gpu_state = self.gpu_state[idx]
-        cpu_state = self.cpu_state[idx]
-        cpu_state['exp_avg'].copy_(gpu_state['exp_avg'].data, non_blocking=True)
-        cpu_state['exp_avg_sq'].copy_(gpu_state['exp_avg_sq'].data, non_blocking=True)
-        if self.half_precision:
-            cpu_state['fp32_param'].copy_(gpu_state['fp32_param'].data, non_blocking=True)
-
-    @nvtx.annotate("free_state", color="purple")
-    def free_state(self, idx):
-        gpu_state = self.gpu_state[idx]
-        gpu_state['exp_avg'] = None
-        gpu_state['exp_avg_sq'] = None
-        if self.half_precision:
-            gpu_state['fp32_param'] = None
-
-    @nvtx.annotate("fetch_state", color="green")
-    def fetch_state(self, idx):
-        gpu_state = self.gpu_state[idx]
-        cpu_state = self.cpu_state[idx]
-        gpu_state['exp_avg'] = cpu_state['exp_avg'].to(device=self.local_device, non_blocking=True)
-        gpu_state['exp_avg_sq'] = cpu_state['exp_avg_sq'].to(device=self.local_device, non_blocking=True)
-        if self.half_precision:
-            gpu_state['fp32_param'] = cpu_state['fp32_param'].to(device=self.local_device, non_blocking=True)
-
     def step(self, closure=None, grads=None, output_params=None, scale=None, grad_norms=None, grad_scaler=None):
         """Performs a single optimization step.
 
@@ -160,14 +115,24 @@ class SpiralGPUAdam(torch.optim.Optimizer):
             if self.found_inf:
                 return loss
 
-        # Calc number of chunked parameter
         for group in self.param_groups:
-            if not 'chunked_param_num' in group:
-                group['chunked_param_num'] = len(slice_tensor_list_in_chunks(group['params'], self.numel_threshold))
+            if len(group['params']) == 0:
+                continue
+            dtype = group['params'][0].dtype
+            bias_correction = 1 if group['bias_correction'] else 0
+            beta1, beta2 = group['betas']
 
-        # Slice params and grads in chunks
-        for group in self.param_groups:
-            fp32_grads = []
+            # assume same step across group now to simplify things
+            # per parameter step can be easily support by making it tensor, or pass list into kernel
+            if 'step' in group:
+                group['step'] += 1
+            else:
+                group['step'] = 1
+
+            # create lists for multi-tensor apply
+            p_16 = []
+            g_32, p_32, m_32, v_32 = [], [], [], []
+
             for p in group['params']:
                 if self.params_have_main_grad and hasattr(p, 'main_grad'):
                     grad = p.main_grad
@@ -179,122 +144,54 @@ class SpiralGPUAdam(torch.optim.Optimizer):
                 if grad.data.is_sparse:
                     raise RuntimeError('SpiralGPUAdam does not support sparse gradients, please consider SparseAdam instead')
 
-                fp32_grads.append(grad.data)
-
-            group['chunked_params'] = slice_tensor_list_in_chunks(group['params'], self.numel_threshold)
-            group['chunked_grads'] = slice_tensor_list_in_chunks(fp32_grads, self.numel_threshold)
-
-        prefetch_events = []
-        compute_events = []
-        free_events = []
-        chunked_idx = -1
-
-        for group in self.param_groups:
-            if group['chunked_param_num'] == 0:
-                continue
-            bias_correction = 1 if group['bias_correction'] else 0
-            beta1, beta2 = group['betas']
-
-            # assume same step across group now to simplify things
-            # per parameter step can be easily support by making it tensor, or pass list into kernel
-            if 'step' in group:
-                group['step'] += 1
-            else:
-                group['step'] = 1
-
-            for i in range(group['chunked_param_num']):
-                chunked_idx += 1
-                gpu_state = self.gpu_state[chunked_idx]
-                p = group['chunked_params'][i]
-                g = group['chunked_grads'][i]
-
-                # Fetch optimizer state
-                with torch.cuda.stream(get_thunder_cuda_manager().Stream("prefetch")):
-                    if not len(gpu_state) == 0:
-                        self.fetch_state(chunked_idx)
-
-                        event = torch.cuda.Event()
-                        event.record()
-                        prefetch_events.append(event)
-
-                # Parameter update
-                with torch.cuda.stream(get_thunder_cuda_manager().Stream("compute")):
-                    # create lists for multi-tensor apply
-                    p_16 = []
-                    g_32, p_32, m_32, v_32 = [], [], [], []
-
-                    # State initialization
-                    if len(gpu_state) == 0:
-                        # Exponential moving average of gradient values
-                        gpu_state['exp_avg'] = torch.zeros_like(p.data).float()
-                        # Exponential moving average of squared gradient values
-                        gpu_state['exp_avg_sq'] = torch.zeros_like(p.data).float()
-                        # Copy fp16 param to fp32 param
-                        if self.half_precision:
-                            gpu_state['fp32_param'] = p.detach().clone().float()
-
-                        self.init_cpu_state(chunked_idx, p.data.shape)
-
-                    if self.half_precision:
-                        p_16.append(p.data)
-                        p_32.append(gpu_state['fp32_param'].data)
+                state = self.state[p]
+                # State initialization
+                if len(state) == 0:
+                    # Exponential moving average of gradient values
+                    state['exp_avg'] = torch.zeros_like(p.data).float()
+                    # Exponential moving average of squared gradient values
+                    state['exp_avg_sq'] = torch.zeros_like(p.data).float()
+                    # Copy fp16 param to fp32 param
+                    if dtype == torch.float16 or dtype == torch.bfloat16:
+                        state['fp32_param'] = p.detach().clone().float()
                     else:
-                        p_32.append(p.data)
+                        state['fp32_param'] = p
+                
+                state['fp32_grad'] = grad
+                grad = None
 
-                    g_32.append(g.data)
-                    m_32.append(gpu_state['exp_avg'])
-                    v_32.append(gpu_state['exp_avg_sq'])
+                if dtype == torch.float16 or dtype == torch.bfloat16:
+                    p_16.append(p.data)
 
-                    if len(prefetch_events) > 0:
-                        prefetch_events.pop(0).wait()
+                g_32.append(state['fp32_grad'].data)
+                p_32.append(state['fp32_param'].data)
+                m_32.append(state['exp_avg'])
+                v_32.append(state['exp_avg_sq'])
 
-                    # Parameter update
-                    multi_tensor_applier(self.multi_tensor_adam,
-                            self._dummy_overflow_buf,
-                            [g_32, p_32, m_32, v_32],
-                            group['lr'],
-                            beta1,
-                            beta2,
-                            group['eps'],
-                            group['step'],
-                            self.adam_w_mode,
-                            bias_correction,
-                            group['weight_decay'])
+            # Parameter update
+            if len(g_32) > 0:
+                multi_tensor_applier(self.multi_tensor_adam,
+                        self._dummy_overflow_buf,
+                        [g_32, p_32, m_32, v_32],
+                        group['lr'],
+                        beta1,
+                        beta2,
+                        group['eps'],
+                        group['step'],
+                        self.adam_w_mode,
+                        bias_correction,
+                        group['weight_decay'])
 
-                    # Copy fp32 params to fp16 params
-                    if self.half_precision:
-                        # Scaling with factor `1.0` is equivalent to copy.
-                        multi_tensor_applier(self.multi_tensor_scale,
-                                            self._dummy_overflow_buf,
-                                            [p_32, p_16],
-                                            1.0)
-
-                    event = torch.cuda.Event()
-                    event.record()
-                    compute_events.append(event)
-
-                # Offload optimizer state
-                with torch.cuda.stream(get_thunder_cuda_manager().Stream("offload")):
-                    if len(compute_events) > 0:
-                            compute_events.pop(0).wait()
-                    self.offload_state(chunked_idx)
-
-                    event = torch.cuda.Event()
-                    event.record()
-                    free_events.append(event)
+            # Copy fp32 params to fp16 params
+            if dtype == torch.float16 or dtype == torch.bfloat16:
+                # Scaling with factor `1.0` is equivalent to copy.
+                multi_tensor_applier(self.multi_tensor_scale,
+                                     self._dummy_overflow_buf,
+                                     [p_32, p_16],
+                                     1.0)
 
         self.step_event = torch.cuda.Event()
         self.step_event.record()
-
-        # Free optimizer state
-        chunked_idx = -1
-        for group in self.param_groups:
-            for i in range(group['chunked_param_num']):
-                chunked_idx += 1
-                if len(free_events) > 0:
-                    free_events.pop(0).synchronize()
-                self.free_state(chunked_idx)
-
         return loss
 
     def rollback(self):
@@ -305,94 +202,48 @@ class SpiralGPUAdam(torch.optim.Optimizer):
         if self.half_precision and self.found_inf:
             return
 
-        prefetch_events = []
-        compute_events = []
-        free_events = []
-        chunked_idx = -1
-
         for group in self.param_groups:
-            assert 'chunked_param_num' in group, "Rollback should be call after run optimizer.step"
-            if group['chunked_param_num'] == 0:
+            if len(group['params']) == 0:
                 continue
+            dtype = group['params'][0].dtype
             bias_correction = 1 if group['bias_correction'] else 0
             beta1, beta2 = group['betas']
 
-            for i in range(group['chunked_param_num']):
-                chunked_idx += 1
-                gpu_state = self.gpu_state[chunked_idx]
-                assert len(gpu_state) != 0, "Rollback should be call after run optimizer.step"
-                p = group['chunked_params'][i]
-                g = group['chunked_grads'][i]
+            # create lists for multi-tensor apply
+            p_16 = []
+            g_32, p_32, m_32, v_32 = [], [], [], []
 
-                # Fetch optimizer state
-                with torch.cuda.stream(get_thunder_cuda_manager().Stream("prefetch")):
-                    self.fetch_state(chunked_idx)
-                    event = torch.cuda.Event()
-                    event.record()
-                    prefetch_events.append(event)
+            for p in group['params']:
+                state = self.state[p]
+                assert len(state) != 0, "Rollback should be call after run optimizer.step"
 
-                # Parameter update
-                with torch.cuda.stream(get_thunder_cuda_manager().Stream("compute")):
-                    # create lists for multi-tensor apply
-                    p_16 = []
-                    g_32, p_32, m_32, v_32 = [], [], [], []
+                if dtype == torch.float16 or dtype == torch.bfloat16:
+                    p_16.append(p.data)
 
-                    if self.half_precision:
-                        p_16.append(p.data)
-                        p_32.append(gpu_state['fp32_param'].data)
-                    else:
-                        p_32.append(p.data)
+                g_32.append(state['fp32_grad'].data)
+                p_32.append(state['fp32_param'].data)
+                m_32.append(state['exp_avg'])
+                v_32.append(state['exp_avg_sq'])
 
-                    g_32.append(g.data)
-                    m_32.append(gpu_state['exp_avg'])
-                    v_32.append(gpu_state['exp_avg_sq'])
-
-                    if len(prefetch_events) > 0:
-                        prefetch_events.pop(0).wait()
-
-                    # Parameter update
-                    multi_tensor_rollback_adamw(
-                        g_32, p_32, m_32, v_32,
-                        group['lr'],
-                        beta1,
-                        beta2,
-                        group['eps'],
-                        group['step'],
-                        bias_correction,
-                        group['weight_decay'])
-
-                    # Copy fp32 params to fp16 params
-                    if self.half_precision:
-                        # Scaling with factor `1.0` is equivalent to copy.
-                        multi_tensor_applier(self.multi_tensor_scale,
-                                            self._dummy_overflow_buf,
-                                            [p_32, p_16],
-                                            1.0)
-
-                    event = torch.cuda.Event()
-                    event.record()
-                    compute_events.append(event)
-                
-                # Offload optimizer state
-                with torch.cuda.stream(get_thunder_cuda_manager().Stream("offload")):
-                    if len(compute_events) > 0:
-                            compute_events.pop(0).wait()
-                    self.offload_state(chunked_idx)
-
-                    event = torch.cuda.Event()
-                    event.record()
-                    free_events.append(event)
-
+            if len(g_32) > 0:
+                multi_tensor_rollback_adamw(
+                    g_32, p_32, m_32, v_32,
+                    group['lr'],
+                    beta1,
+                    beta2,
+                    group['eps'],
+                    group['step'],
+                    bias_correction,
+                    group['weight_decay'])
             group['step'] -= 1
 
-        # Free optimizer state
-        chunked_idx = -1
-        for group in self.param_groups:
-            for i in range(group['chunked_param_num']):
-                chunked_idx += 1
-                if len(free_events) > 0:
-                    free_events.pop(0).synchronize()
-                self.free_state(chunked_idx)
+            # Copy fp32 params to fp16 params
+            if dtype == torch.float16 or dtype == torch.bfloat16:
+                # Scaling with factor `1.0` is equivalent to copy.
+                multi_tensor_applier(self.multi_tensor_scale,
+                                     self._dummy_overflow_buf,
+                                     [p_32, p_16],
+                                     1.0)
 
     def sync(self, found_inf=None):
         if self.step_event is not None:
@@ -445,16 +296,3 @@ def rollback_adamw(
     p.add_(update).div_(1 - lr * decay)
     v.addcmul_(g, g, value=beta2 - 1).div_(beta2)
     m.add_(g, alpha=beta1 - 1).div_(beta1)
-
-
-def slice_tensor_list_in_chunks(tensor_list, chunk_size=0):
-    sliced_tensor_list = []
-    
-    for tensor in tensor_list:
-        current_index = 0
-        while current_index < tensor.numel():
-            end = min(current_index + chunk_size, tensor.numel())
-            sliced_tensor_list.append(tensor.view(-1)[current_index:end])
-            current_index += chunk_size
-
-    return sliced_tensor_list

--- a/megatron/spiral/optimizer/gpu_adam.py
+++ b/megatron/spiral/optimizer/gpu_adam.py
@@ -61,9 +61,11 @@ class SpiralGPUAdam(torch.optim.Optimizer):
         self.inv_scale = 0
         self.params_have_main_grad = True
         self.step_event = None
+        self.found_inf = False
 
         self.local_device = torch.cuda.current_device()
         self.remote_device = torch.device("cpu")
+        self.gpu_state = defaultdict(dict)
         self.cpu_state = defaultdict(dict)
         self.numel_threshold = get_args().hidden_size * get_args().hidden_size
 
@@ -113,31 +115,32 @@ class SpiralGPUAdam(torch.optim.Optimizer):
 
     @nvtx.annotate("offload_state", color="pink")
     def offload_state(self, p):
-        state = self.state[p]
+        gpu_state = self.gpu_state[p]
         cpu_state = self.cpu_state[p]
-        cpu_state['exp_avg'].copy_(state['exp_avg'].data, non_blocking=True)
-        cpu_state['exp_avg_sq'].copy_(state['exp_avg_sq'].data, non_blocking=True)
-        cpu_state['fp32_param'].copy_(state['fp32_param'].data, non_blocking=True)
-        cpu_state['fp32_grad'].copy_(state['fp32_grad'].data, non_blocking=True)
+        cpu_state['exp_avg'].copy_(gpu_state['exp_avg'].data, non_blocking=True)
+        cpu_state['exp_avg_sq'].copy_(gpu_state['exp_avg_sq'].data, non_blocking=True)
+        cpu_state['fp32_param'].copy_(gpu_state['fp32_param'].data, non_blocking=True)
+        cpu_state['fp32_grad'].copy_(gpu_state['fp32_grad'].data, non_blocking=True)
 
     @nvtx.annotate("free_state", color="purple")
     def free_state(self, p):
-        state = self.state[p]
-        state['exp_avg'] = None
-        state['exp_avg_sq'] = None
-        state['fp32_param'] = None
-        state['fp32_grad'] = None
+        gpu_state = self.gpu_state[p]
+        gpu_state['exp_avg'] = None
+        gpu_state['exp_avg_sq'] = None
+        gpu_state['fp32_param'] = None
+        gpu_state['fp32_grad'] = None
 
     @nvtx.annotate("fetch_state", color="green")
     def fetch_state(self, p, grad_temp=False):
-        state = self.state[p]
+        gpu_state = self.gpu_state[p]
         cpu_state = self.cpu_state[p]
-        state['exp_avg'] = cpu_state['exp_avg'].to(device=self.local_device, non_blocking=True)
-        state['exp_avg_sq'] = cpu_state['exp_avg_sq'].to(device=self.local_device, non_blocking=True)
-        state['fp32_param'] = cpu_state['fp32_param'].to(device=self.local_device, non_blocking=True)
+        gpu_state['exp_avg'] = cpu_state['exp_avg'].to(device=self.local_device, non_blocking=True)
+        gpu_state['exp_avg_sq'] = cpu_state['exp_avg_sq'].to(device=self.local_device, non_blocking=True)
+        gpu_state['fp32_param'] = cpu_state['fp32_param'].to(device=self.local_device, non_blocking=True)
 
+        # TODO: remove grad_temp
         if grad_temp:
-            state['fp32_grad'] = cpu_state['fp32_grad'].to(device=self.local_device, non_blocking=True)
+            gpu_state['fp32_grad'] = cpu_state['fp32_grad'].to(device=self.local_device, non_blocking=True)
 
     def step(self, closure=None, grads=None, output_params=None, scale=None, grad_norms=None, grad_scaler=None):
         """Performs a single optimization step.
@@ -160,77 +163,92 @@ class SpiralGPUAdam(torch.optim.Optimizer):
             if self.found_inf:
                 return loss
 
+        # TODO: This is just for dict key!! how about use other key? or just index?
+        for group in self.param_groups:
+            if not 'chunked_param' in group:
+                group['chunked_param'] = slice_tensor_list_in_chunks(group['params'], self.numel_threshold)
+
+        # Slice params and grads in chunks
+        for group in self.param_groups:
+            fp32_grads = []
+            for p in group['params']:
+                if self.params_have_main_grad and hasattr(p, 'main_grad'):
+                    grad = p.main_grad
+                else:
+                    grad = p.grad
+
+                if grad is None:
+                    continue
+                if grad.data.is_sparse:
+                    raise RuntimeError('SpiralGPUAdam does not support sparse gradients, please consider SparseAdam instead')
+
+                fp32_grads.append(grad.data)
+
+            # TODO: change the key name
+            group['chunked_real_param'] = slice_tensor_list_in_chunks(group['params'], self.numel_threshold)
+            group['chunked_grad'] = slice_tensor_list_in_chunks(fp32_grads, self.numel_threshold)
+
         prefetch_events = []
         compute_events = []
         free_events = []
 
-        # Fetch optimizer state
-        with torch.cuda.stream(get_thunder_cuda_manager().Stream("prefetch")):
-            for group in self.param_groups:
-                for i, p in enumerate(group['params']):
-                    state = self.state[p]
-                    if not len(state) == 0:
+        for group in self.param_groups:
+            if len(group['chunked_param']) == 0:
+                continue
+            dtype = group['chunked_param'][0].dtype
+            bias_correction = 1 if group['bias_correction'] else 0
+            beta1, beta2 = group['betas']
+
+            # assume same step across group now to simplify things
+            # per parameter step can be easily support by making it tensor, or pass list into kernel
+            if 'step' in group:
+                group['step'] += 1
+            else:
+                group['step'] = 1
+
+            for i, p in enumerate(group['chunked_param']):
+
+                # Fetch optimizer state
+                with torch.cuda.stream(get_thunder_cuda_manager().Stream("prefetch")):
+                    gpu_state = self.gpu_state[p]
+                    if not len(gpu_state) == 0:
                         self.fetch_state(p)
+
                         event = torch.cuda.Event()
                         event.record()
                         prefetch_events.append(event)
 
-        # Parameter update
-        with torch.cuda.stream(get_thunder_cuda_manager().Stream("compute")):
-            for group in self.param_groups:
-                if len(group['params']) == 0:
-                    continue
-                dtype = group['params'][0].dtype
-                bias_correction = 1 if group['bias_correction'] else 0
-                beta1, beta2 = group['betas']
-
-                # assume same step across group now to simplify things
-                # per parameter step can be easily support by making it tensor, or pass list into kernel
-                if 'step' in group:
-                    group['step'] += 1
-                else:
-                    group['step'] = 1
-
-                for i, p in enumerate(group['params']):
+                # Parameter update
+                with torch.cuda.stream(get_thunder_cuda_manager().Stream("compute")):
                     # create lists for multi-tensor apply
                     p_16 = []
                     g_32, p_32, m_32, v_32 = [], [], [], []
 
-                    if self.params_have_main_grad and hasattr(p, 'main_grad'):
-                        grad = p.main_grad
-                    else:
-                        grad = p.grad
-
-                    if grad is None:
-                        continue
-                    if grad.data.is_sparse:
-                        raise RuntimeError('SpiralGPUAdam does not support sparse gradients, please consider SparseAdam instead')
-
-                    state = self.state[p]
+                    gpu_state = self.gpu_state[p]
                     # State initialization
-                    if len(state) == 0:
+                    if len(gpu_state) == 0:
                         # Exponential moving average of gradient values
-                        state['exp_avg'] = torch.zeros_like(p.data).float()
+                        gpu_state['exp_avg'] = torch.zeros_like(p.data).float()
                         # Exponential moving average of squared gradient values
-                        state['exp_avg_sq'] = torch.zeros_like(p.data).float()
+                        gpu_state['exp_avg_sq'] = torch.zeros_like(p.data).float()
                         # Copy fp16 param to fp32 param
                         if dtype == torch.float16 or dtype == torch.bfloat16:
-                            state['fp32_param'] = p.detach().clone().float()
+                            gpu_state['fp32_param'] = p.detach().clone().float()
                         else:
-                            state['fp32_param'] = p
+                            gpu_state['fp32_param'] = p
                     
                         self.init_cpu_state(p)
 
-                    state['fp32_grad'] = grad
-                    grad = None
+                    gpu_state['fp32_grad'] = group['chunked_grad'][i]
+                    group['chunked_grad'][i] = None
 
                     if dtype == torch.float16 or dtype == torch.bfloat16:
-                        p_16.append(p.data)
+                        p_16.append(group['chunked_real_param'][i].data)
 
-                    g_32.append(state['fp32_grad'].data)
-                    p_32.append(state['fp32_param'].data)
-                    m_32.append(state['exp_avg'])
-                    v_32.append(state['exp_avg_sq'])
+                    g_32.append(gpu_state['fp32_grad'].data)
+                    p_32.append(gpu_state['fp32_param'].data)
+                    m_32.append(gpu_state['exp_avg'])
+                    v_32.append(gpu_state['exp_avg_sq'])
 
                     if len(prefetch_events) > 0:
                         prefetch_events.pop(0).wait()
@@ -260,27 +278,22 @@ class SpiralGPUAdam(torch.optim.Optimizer):
                     event.record()
                     compute_events.append(event)
 
-        # Offload optimizer state
-        with torch.cuda.stream(get_thunder_cuda_manager().Stream("offload")):
-            if len(compute_events) > 0:
-                    compute_events.pop(0).wait()
-            for group in self.param_groups:
-                for i, p in enumerate(group['params']):
-                    self.offload_state(p)
+                # Offload optimizer state
+                with torch.cuda.stream(get_thunder_cuda_manager().Stream("offload")):
                     if len(compute_events) > 0:
-                        compute_events.pop(0).wait()
+                            compute_events.pop(0).wait()
+                    self.offload_state(p)
 
                     event = torch.cuda.Event()
                     event.record()
                     free_events.append(event)
-        
-        if len(free_events) > 0:
-            free_events.pop(0).synchronize()
+
+        # Free optimizer state
         for group in self.param_groups:
-            for i, p in enumerate(group['params']):
-                self.free_state(p)
+            for p in group['chunked_param']:
                 if len(free_events) > 0:
                     free_events.pop(0).synchronize()
+                self.free_state(p)
 
         self.step_event = torch.cuda.Event()
         self.step_event.record()
@@ -392,3 +405,16 @@ def rollback_adamw(
     p.add_(update).div_(1 - lr * decay)
     v.addcmul_(g, g, value=beta2 - 1).div_(beta2)
     m.add_(g, alpha=beta1 - 1).div_(beta1)
+
+
+def slice_tensor_list_in_chunks(tensor_list, chunk_size=0):
+    sliced_tensor_list = []
+    
+    for tensor in tensor_list:
+        current_index = 0
+        while current_index < tensor.numel():
+            end = min(current_index + chunk_size, tensor.numel())
+            sliced_tensor_list.append(tensor.view(-1)[current_index:end])
+            current_index += chunk_size
+
+    return sliced_tensor_list

--- a/megatron/spiral/optimizer/gpu_adam.py
+++ b/megatron/spiral/optimizer/gpu_adam.py
@@ -105,35 +105,35 @@ class SpiralGPUAdam(torch.optim.Optimizer):
 
         return found_inf.item() > 0
 
-    def init_cpu_state(self, p):
-        cpu_state = self.cpu_state[p]
+    def init_cpu_state(self, idx, shape):
+        cpu_state = self.cpu_state[idx]
         if len(cpu_state) == 0:
-            cpu_state['exp_avg'] = torch.empty(p.data.shape, device=self.remote_device, dtype=torch.float32, pin_memory=True)
-            cpu_state['exp_avg_sq'] = torch.empty(p.data.shape, device=self.remote_device, dtype=torch.float32, pin_memory=True)
-            cpu_state['fp32_param'] = torch.empty(p.data.shape, device=self.remote_device, dtype=torch.float32, pin_memory=True)
-            cpu_state['fp32_grad'] = torch.empty(p.data.shape, device=self.remote_device, dtype=torch.float32, pin_memory=True)
+            cpu_state['exp_avg'] = torch.empty(shape, device=self.remote_device, dtype=torch.float32, pin_memory=True)
+            cpu_state['exp_avg_sq'] = torch.empty(shape, device=self.remote_device, dtype=torch.float32, pin_memory=True)
+            cpu_state['fp32_param'] = torch.empty(shape, device=self.remote_device, dtype=torch.float32, pin_memory=True)
+            cpu_state['fp32_grad'] = torch.empty(shape, device=self.remote_device, dtype=torch.float32, pin_memory=True)
 
     @nvtx.annotate("offload_state", color="pink")
-    def offload_state(self, p):
-        gpu_state = self.gpu_state[p]
-        cpu_state = self.cpu_state[p]
+    def offload_state(self, idx):
+        gpu_state = self.gpu_state[idx]
+        cpu_state = self.cpu_state[idx]
         cpu_state['exp_avg'].copy_(gpu_state['exp_avg'].data, non_blocking=True)
         cpu_state['exp_avg_sq'].copy_(gpu_state['exp_avg_sq'].data, non_blocking=True)
         cpu_state['fp32_param'].copy_(gpu_state['fp32_param'].data, non_blocking=True)
         cpu_state['fp32_grad'].copy_(gpu_state['fp32_grad'].data, non_blocking=True)
 
     @nvtx.annotate("free_state", color="purple")
-    def free_state(self, p):
-        gpu_state = self.gpu_state[p]
+    def free_state(self, idx):
+        gpu_state = self.gpu_state[idx]
         gpu_state['exp_avg'] = None
         gpu_state['exp_avg_sq'] = None
         gpu_state['fp32_param'] = None
         gpu_state['fp32_grad'] = None
 
     @nvtx.annotate("fetch_state", color="green")
-    def fetch_state(self, p, grad_temp=False):
-        gpu_state = self.gpu_state[p]
-        cpu_state = self.cpu_state[p]
+    def fetch_state(self, idx, grad_temp=False):
+        gpu_state = self.gpu_state[idx]
+        cpu_state = self.cpu_state[idx]
         gpu_state['exp_avg'] = cpu_state['exp_avg'].to(device=self.local_device, non_blocking=True)
         gpu_state['exp_avg_sq'] = cpu_state['exp_avg_sq'].to(device=self.local_device, non_blocking=True)
         gpu_state['fp32_param'] = cpu_state['fp32_param'].to(device=self.local_device, non_blocking=True)
@@ -163,10 +163,10 @@ class SpiralGPUAdam(torch.optim.Optimizer):
             if self.found_inf:
                 return loss
 
-        # TODO: This is just for dict key!! how about use other key? or just index?
+        # Calc number of chunked parameter
         for group in self.param_groups:
-            if not 'chunked_param' in group:
-                group['chunked_param'] = slice_tensor_list_in_chunks(group['params'], self.numel_threshold)
+            if not 'chunked_param_num' in group:
+                group['chunked_param_num'] = len(slice_tensor_list_in_chunks(group['params'], self.numel_threshold))
 
         # Slice params and grads in chunks
         for group in self.param_groups:
@@ -184,18 +184,18 @@ class SpiralGPUAdam(torch.optim.Optimizer):
 
                 fp32_grads.append(grad.data)
 
-            # TODO: change the key name
-            group['chunked_real_param'] = slice_tensor_list_in_chunks(group['params'], self.numel_threshold)
-            group['chunked_grad'] = slice_tensor_list_in_chunks(fp32_grads, self.numel_threshold)
+            group['chunked_params'] = slice_tensor_list_in_chunks(group['params'], self.numel_threshold)
+            group['chunked_grads'] = slice_tensor_list_in_chunks(fp32_grads, self.numel_threshold)
 
         prefetch_events = []
         compute_events = []
         free_events = []
+        chunked_idx = -1
 
         for group in self.param_groups:
-            if len(group['chunked_param']) == 0:
+            if group['chunked_param_num'] == 0:
                 continue
-            dtype = group['chunked_param'][0].dtype
+            dtype = group['params'][0].dtype
             bias_correction = 1 if group['bias_correction'] else 0
             beta1, beta2 = group['betas']
 
@@ -206,13 +206,16 @@ class SpiralGPUAdam(torch.optim.Optimizer):
             else:
                 group['step'] = 1
 
-            for i, p in enumerate(group['chunked_param']):
+            for i in range(group['chunked_param_num']):
+                chunked_idx += 1
+                gpu_state = self.gpu_state[chunked_idx]
+                p = group['chunked_params'][i]
+                g = group['chunked_grads'][i]
 
                 # Fetch optimizer state
                 with torch.cuda.stream(get_thunder_cuda_manager().Stream("prefetch")):
-                    gpu_state = self.gpu_state[p]
                     if not len(gpu_state) == 0:
-                        self.fetch_state(p)
+                        self.fetch_state(chunked_idx)
 
                         event = torch.cuda.Event()
                         event.record()
@@ -224,7 +227,6 @@ class SpiralGPUAdam(torch.optim.Optimizer):
                     p_16 = []
                     g_32, p_32, m_32, v_32 = [], [], [], []
 
-                    gpu_state = self.gpu_state[p]
                     # State initialization
                     if len(gpu_state) == 0:
                         # Exponential moving average of gradient values
@@ -236,14 +238,14 @@ class SpiralGPUAdam(torch.optim.Optimizer):
                             gpu_state['fp32_param'] = p.detach().clone().float()
                         else:
                             gpu_state['fp32_param'] = p
-                    
-                        self.init_cpu_state(p)
 
-                    gpu_state['fp32_grad'] = group['chunked_grad'][i]
-                    group['chunked_grad'][i] = None
+                        self.init_cpu_state(chunked_idx, p.data.shape)
+
+                    gpu_state['fp32_grad'] = g
+                    g = None
 
                     if dtype == torch.float16 or dtype == torch.bfloat16:
-                        p_16.append(group['chunked_real_param'][i].data)
+                        p_16.append(p.data)
 
                     g_32.append(gpu_state['fp32_grad'].data)
                     p_32.append(gpu_state['fp32_param'].data)
@@ -282,18 +284,20 @@ class SpiralGPUAdam(torch.optim.Optimizer):
                 with torch.cuda.stream(get_thunder_cuda_manager().Stream("offload")):
                     if len(compute_events) > 0:
                             compute_events.pop(0).wait()
-                    self.offload_state(p)
+                    self.offload_state(chunked_idx)
 
                     event = torch.cuda.Event()
                     event.record()
                     free_events.append(event)
 
         # Free optimizer state
+        chunked_idx = -1
         for group in self.param_groups:
-            for p in group['chunked_param']:
+            for i in range(group['chunked_param_num']):
+                chunked_idx += 1
                 if len(free_events) > 0:
                     free_events.pop(0).synchronize()
-                self.free_state(p)
+                self.free_state(chunked_idx)
 
         self.step_event = torch.cuda.Event()
         self.step_event.record()

--- a/megatron/spiral/optimizer/gpu_adam.py
+++ b/megatron/spiral/optimizer/gpu_adam.py
@@ -162,6 +162,7 @@ class SpiralGPUAdam(torch.optim.Optimizer):
 
         prefetch_events = []
         compute_events = []
+        free_events = []
 
         # Fetch optimizer state
         with torch.cuda.stream(get_thunder_cuda_manager().Stream("prefetch")):
@@ -269,9 +270,20 @@ class SpiralGPUAdam(torch.optim.Optimizer):
                     if len(compute_events) > 0:
                         compute_events.pop(0).wait()
 
-            self.step_event = torch.cuda.Event()
-            self.step_event.record()
+                    event = torch.cuda.Event()
+                    event.record()
+                    free_events.append(event)
+        
+        if len(free_events) > 0:
+            free_events.pop(0).synchronize()
+        for group in self.param_groups:
+            for i, p in enumerate(group['params']):
+                self.free_state(p)
+                if len(free_events) > 0:
+                    free_events.pop(0).synchronize()
 
+        self.step_event = torch.cuda.Event()
+        self.step_event.record()
         return loss
 
     def rollback(self):

--- a/megatron/spiral/optimizer/gpu_chunked_adam.py
+++ b/megatron/spiral/optimizer/gpu_chunked_adam.py
@@ -1,0 +1,460 @@
+# Most of the code here has been copied from:
+#   https://github.com/NVIDIA/apex/blob/741bdf50825a97664db08574981962d66436d16a/apex/optimizers/fused_adam.py
+#   https://github.com/sail-sg/zero-bubble-pipeline-parallelism
+# with some modifications.
+
+import torch
+import nvtx
+from apex.multi_tensor_apply import multi_tensor_applier
+from collections import defaultdict
+
+from megatron import get_args
+from megatron.spiral.initialize import get_thunder_cuda_manager
+
+
+class SpiralGPUChunkedAdam(torch.optim.Optimizer):
+
+    """Implements Adam algorithm.
+
+    Arguments:
+        params (iterable): iterable of parameters to optimize or dicts defining
+            parameter groups.
+        lr (float, optional): learning rate. (default: 1e-3)
+        betas (Tuple[float, float], optional): coefficients used for computing
+            running averages of gradient and its square. (default: (0.9, 0.999))
+        eps (float, optional): term added to the denominator to improve
+            numerical stability. (default: 1e-8)
+        weight_decay (float, optional): weight decay (L2 penalty) (default: 0)
+        amsgrad (boolean, optional): whether to use the AMSGrad variant of this
+            algorithm from the paper `On the Convergence of Adam and Beyond`_
+            (default: False) NOT SUPPORTED in FusedAdam!
+        adam_w_mode (boolean, optional): Apply L2 regularization or weight decay
+            True for decoupled weight decay(also known as AdamW) (default: True)
+        set_grad_none (bool, optional): whether set grad to None when zero_grad()
+            method is called. (default: True)
+        capturable (bool, optional): whether to use the version of the optimizer
+            that can be used with CUDA Graphs. (default: False)
+        master_weights (bool, optional): whether to maintain FP32 master weights
+           in the optimizer with FP16 mixed precision training, currently can
+           only be used with capturable set to True. (default: False)
+    """
+
+    def __init__(self, params, lr=1e-3, bias_correction=True,
+                 betas=(0.9, 0.999), eps=1e-8, adam_w_mode=True,
+                 weight_decay=0., amsgrad=False, set_grad_none=True,
+                 capturable=False, master_weights=False):
+
+        if amsgrad:
+            raise RuntimeError('SpiralGPUAdam does not support the AMSGrad variant.')
+        if capturable or master_weights:
+            raise RuntimeError('SpiralGPUAdam does not support catureable or master_weights.')
+        # If the optimizer is capturable then LR should be a tensor (on GPU)
+        lr = torch.tensor(lr, dtype=torch.float32) if capturable else lr
+        defaults = dict(lr=lr, bias_correction=bias_correction,
+                        betas=betas, eps=eps, weight_decay=weight_decay)
+        super(SpiralGPUChunkedAdam, self).__init__(params, defaults)
+        self.adam_w_mode = 1 if adam_w_mode else 0
+        self.set_grad_none = set_grad_none
+
+        # For unscale in mixed precision
+        self.half_precision = get_args().fp16
+        self.inv_scale = 0
+        self.params_have_main_grad = True
+        self.step_event = None
+        self.found_inf = False
+
+        self.local_device = torch.cuda.current_device()
+        self.remote_device = torch.device("cpu")
+        self.gpu_state = defaultdict(dict)
+        self.cpu_state = defaultdict(dict)
+        self.numel_threshold = get_args().hidden_size * get_args().hidden_size
+
+        if multi_tensor_applier.available:
+            import amp_C
+            # Skip buffer
+            self._dummy_overflow_buf = torch.cuda.IntTensor([0])
+            self.multi_tensor_adam = amp_C.multi_tensor_adam
+            self.multi_tensor_scale = amp_C.multi_tensor_scale
+        else:
+            raise RuntimeError('SpiralGPUAdam requires cuda extensions')
+
+    def zero_grad(self):
+        if self.set_grad_none:
+            for group in self.param_groups:
+                for p in group['params']:
+                    p.grad = None
+        else:
+            super(SpiralGPUChunkedAdam, self).zero_grad()
+
+    def _unscale_grads_and_check_inf(self):
+        fp32_grads = []
+        for group in self.param_groups:
+            for p in group['params']:
+                if self.params_have_main_grad and hasattr(p, 'main_grad'):
+                    if p.main_grad is not None:
+                        p.main_grad = p.main_grad.float()
+                        fp32_grads.append(p.main_grad.data)
+                else:
+                    if p.grad is not None:
+                        p.grad = p.grad.float()
+                        fp32_grads.append(p.grad.data)
+
+        found_inf = torch.cuda.FloatTensor([0.0])
+        inv_scale = torch.cuda.FloatTensor([self.inv_scale])
+        torch._amp_foreach_non_finite_check_and_unscale_(fp32_grads, found_inf, inv_scale)
+
+        return found_inf.item() > 0
+
+    def init_cpu_state(self, idx, shape):
+        cpu_state = self.cpu_state[idx]
+        if len(cpu_state) == 0:
+            cpu_state['exp_avg'] = torch.empty(shape, device=self.remote_device, dtype=torch.float32, pin_memory=True)
+            cpu_state['exp_avg_sq'] = torch.empty(shape, device=self.remote_device, dtype=torch.float32, pin_memory=True)
+            if self.half_precision:
+                cpu_state['fp32_param'] = torch.empty(shape, device=self.remote_device, dtype=torch.float32, pin_memory=True)
+
+    @nvtx.annotate("offload_state", color="pink")
+    def offload_state(self, idx):
+        gpu_state = self.gpu_state[idx]
+        cpu_state = self.cpu_state[idx]
+        cpu_state['exp_avg'].copy_(gpu_state['exp_avg'].data, non_blocking=True)
+        cpu_state['exp_avg_sq'].copy_(gpu_state['exp_avg_sq'].data, non_blocking=True)
+        if self.half_precision:
+            cpu_state['fp32_param'].copy_(gpu_state['fp32_param'].data, non_blocking=True)
+
+    @nvtx.annotate("free_state", color="purple")
+    def free_state(self, idx):
+        gpu_state = self.gpu_state[idx]
+        gpu_state['exp_avg'] = None
+        gpu_state['exp_avg_sq'] = None
+        if self.half_precision:
+            gpu_state['fp32_param'] = None
+
+    @nvtx.annotate("fetch_state", color="green")
+    def fetch_state(self, idx):
+        gpu_state = self.gpu_state[idx]
+        cpu_state = self.cpu_state[idx]
+        gpu_state['exp_avg'] = cpu_state['exp_avg'].to(device=self.local_device, non_blocking=True)
+        gpu_state['exp_avg_sq'] = cpu_state['exp_avg_sq'].to(device=self.local_device, non_blocking=True)
+        if self.half_precision:
+            gpu_state['fp32_param'] = cpu_state['fp32_param'].to(device=self.local_device, non_blocking=True)
+
+    def step(self, closure=None, grads=None, output_params=None, scale=None, grad_norms=None, grad_scaler=None):
+        """Performs a single optimization step.
+
+        Arguments:
+            closure (callable, optional): A closure that reevaluates the model
+                and returns the loss.
+
+        The remaining arguments are deprecated, and are only retained (for the moment) for error-checking purposes.
+        """
+        if any(p is not None for p in [grads, output_params, scale, grad_norms]):
+            raise RuntimeError('SpiralGPUAdam has been updated.  Simply initialize it identically to torch.optim.Adam, and call step() with no arguments.')
+        loss = None
+        if closure is not None:
+            loss = closure()
+
+        # Unscale fp32 grads and check for inf/nan
+        if self.half_precision:
+            self.found_inf = self._unscale_grads_and_check_inf()
+            if self.found_inf:
+                return loss
+
+        # Calc number of chunked parameter
+        for group in self.param_groups:
+            if not 'chunked_param_num' in group:
+                group['chunked_param_num'] = len(slice_tensor_list_in_chunks(group['params'], self.numel_threshold))
+
+        # Slice params and grads in chunks
+        for group in self.param_groups:
+            fp32_grads = []
+            for p in group['params']:
+                if self.params_have_main_grad and hasattr(p, 'main_grad'):
+                    grad = p.main_grad
+                else:
+                    grad = p.grad
+
+                if grad is None:
+                    continue
+                if grad.data.is_sparse:
+                    raise RuntimeError('SpiralGPUAdam does not support sparse gradients, please consider SparseAdam instead')
+
+                fp32_grads.append(grad.data)
+
+            group['chunked_params'] = slice_tensor_list_in_chunks(group['params'], self.numel_threshold)
+            group['chunked_grads'] = slice_tensor_list_in_chunks(fp32_grads, self.numel_threshold)
+
+        prefetch_events = []
+        compute_events = []
+        free_events = []
+        chunked_idx = -1
+
+        for group in self.param_groups:
+            if group['chunked_param_num'] == 0:
+                continue
+            bias_correction = 1 if group['bias_correction'] else 0
+            beta1, beta2 = group['betas']
+
+            # assume same step across group now to simplify things
+            # per parameter step can be easily support by making it tensor, or pass list into kernel
+            if 'step' in group:
+                group['step'] += 1
+            else:
+                group['step'] = 1
+
+            for i in range(group['chunked_param_num']):
+                chunked_idx += 1
+                gpu_state = self.gpu_state[chunked_idx]
+                p = group['chunked_params'][i]
+                g = group['chunked_grads'][i]
+
+                # Fetch optimizer state
+                with torch.cuda.stream(get_thunder_cuda_manager().Stream("prefetch")):
+                    if not len(gpu_state) == 0:
+                        self.fetch_state(chunked_idx)
+
+                        event = torch.cuda.Event()
+                        event.record()
+                        prefetch_events.append(event)
+
+                # Parameter update
+                with torch.cuda.stream(get_thunder_cuda_manager().Stream("compute")):
+                    # create lists for multi-tensor apply
+                    p_16 = []
+                    g_32, p_32, m_32, v_32 = [], [], [], []
+
+                    # State initialization
+                    if len(gpu_state) == 0:
+                        # Exponential moving average of gradient values
+                        gpu_state['exp_avg'] = torch.zeros_like(p.data).float()
+                        # Exponential moving average of squared gradient values
+                        gpu_state['exp_avg_sq'] = torch.zeros_like(p.data).float()
+                        # Copy fp16 param to fp32 param
+                        if self.half_precision:
+                            gpu_state['fp32_param'] = p.detach().clone().float()
+
+                        self.init_cpu_state(chunked_idx, p.data.shape)
+
+                    if self.half_precision:
+                        p_16.append(p.data)
+                        p_32.append(gpu_state['fp32_param'].data)
+                    else:
+                        p_32.append(p.data)
+
+                    g_32.append(g.data)
+                    m_32.append(gpu_state['exp_avg'])
+                    v_32.append(gpu_state['exp_avg_sq'])
+
+                    if len(prefetch_events) > 0:
+                        prefetch_events.pop(0).wait()
+
+                    # Parameter update
+                    multi_tensor_applier(self.multi_tensor_adam,
+                            self._dummy_overflow_buf,
+                            [g_32, p_32, m_32, v_32],
+                            group['lr'],
+                            beta1,
+                            beta2,
+                            group['eps'],
+                            group['step'],
+                            self.adam_w_mode,
+                            bias_correction,
+                            group['weight_decay'])
+
+                    # Copy fp32 params to fp16 params
+                    if self.half_precision:
+                        # Scaling with factor `1.0` is equivalent to copy.
+                        multi_tensor_applier(self.multi_tensor_scale,
+                                            self._dummy_overflow_buf,
+                                            [p_32, p_16],
+                                            1.0)
+
+                    event = torch.cuda.Event()
+                    event.record()
+                    compute_events.append(event)
+
+                # Offload optimizer state
+                with torch.cuda.stream(get_thunder_cuda_manager().Stream("offload")):
+                    if len(compute_events) > 0:
+                            compute_events.pop(0).wait()
+                    self.offload_state(chunked_idx)
+
+                    event = torch.cuda.Event()
+                    event.record()
+                    free_events.append(event)
+
+        self.step_event = torch.cuda.Event()
+        self.step_event.record()
+
+        # Free optimizer state
+        chunked_idx = -1
+        for group in self.param_groups:
+            for i in range(group['chunked_param_num']):
+                chunked_idx += 1
+                if len(free_events) > 0:
+                    free_events.pop(0).synchronize()
+                self.free_state(chunked_idx)
+
+        return loss
+
+    def rollback(self):
+        if not self.adam_w_mode:
+            raise RuntimeError("SpiralGPUAdam only supports rollback for adam_w_mode.")
+
+        # if found_inf is True, skip rollback
+        if self.half_precision and self.found_inf:
+            return
+
+        prefetch_events = []
+        compute_events = []
+        free_events = []
+        chunked_idx = -1
+
+        for group in self.param_groups:
+            assert 'chunked_param_num' in group, "Rollback should be call after run optimizer.step"
+            if group['chunked_param_num'] == 0:
+                continue
+            bias_correction = 1 if group['bias_correction'] else 0
+            beta1, beta2 = group['betas']
+
+            for i in range(group['chunked_param_num']):
+                chunked_idx += 1
+                gpu_state = self.gpu_state[chunked_idx]
+                assert len(gpu_state) != 0, "Rollback should be call after run optimizer.step"
+                p = group['chunked_params'][i]
+                g = group['chunked_grads'][i]
+
+                # Fetch optimizer state
+                with torch.cuda.stream(get_thunder_cuda_manager().Stream("prefetch")):
+                    self.fetch_state(chunked_idx)
+                    event = torch.cuda.Event()
+                    event.record()
+                    prefetch_events.append(event)
+
+                # Parameter update
+                with torch.cuda.stream(get_thunder_cuda_manager().Stream("compute")):
+                    # create lists for multi-tensor apply
+                    p_16 = []
+                    g_32, p_32, m_32, v_32 = [], [], [], []
+
+                    if self.half_precision:
+                        p_16.append(p.data)
+                        p_32.append(gpu_state['fp32_param'].data)
+                    else:
+                        p_32.append(p.data)
+
+                    g_32.append(g.data)
+                    m_32.append(gpu_state['exp_avg'])
+                    v_32.append(gpu_state['exp_avg_sq'])
+
+                    if len(prefetch_events) > 0:
+                        prefetch_events.pop(0).wait()
+
+                    # Parameter update
+                    multi_tensor_rollback_adamw(
+                        g_32, p_32, m_32, v_32,
+                        group['lr'],
+                        beta1,
+                        beta2,
+                        group['eps'],
+                        group['step'],
+                        bias_correction,
+                        group['weight_decay'])
+
+                    # Copy fp32 params to fp16 params
+                    if self.half_precision:
+                        # Scaling with factor `1.0` is equivalent to copy.
+                        multi_tensor_applier(self.multi_tensor_scale,
+                                            self._dummy_overflow_buf,
+                                            [p_32, p_16],
+                                            1.0)
+
+                    event = torch.cuda.Event()
+                    event.record()
+                    compute_events.append(event)
+                
+                # Offload optimizer state
+                with torch.cuda.stream(get_thunder_cuda_manager().Stream("offload")):
+                    if len(compute_events) > 0:
+                            compute_events.pop(0).wait()
+                    self.offload_state(chunked_idx)
+
+                    event = torch.cuda.Event()
+                    event.record()
+                    free_events.append(event)
+
+            group['step'] -= 1
+
+        # Free optimizer state
+        chunked_idx = -1
+        for group in self.param_groups:
+            for i in range(group['chunked_param_num']):
+                chunked_idx += 1
+                if len(free_events) > 0:
+                    free_events.pop(0).synchronize()
+                self.free_state(chunked_idx)
+
+    def sync(self, found_inf=None):
+        if self.step_event is not None:
+            self.step_event.synchronize()
+            self.step_event = None
+
+        if found_inf is not None:
+            found_inf.fill_(1.0 if self.found_inf else 0.0)
+
+
+def multi_tensor_rollback_adamw(
+    g_list, p_list, m_list, v_list,
+    lr,
+    beta1,
+    beta2,
+    eps,
+    step,
+    bias_correction,
+    weight_decay,
+):
+    beta1_correction, beta2_correction = 1.0, 1.0
+    if bias_correction == 1:
+        beta1_correction = 1 - beta1 ** step
+        beta2_correction = 1 - beta2 ** step
+    for i, p in enumerate(p_list):
+        rollback_adamw(
+            g_list[i], p_list[i], m_list[i], v_list[i],
+            lr,
+            beta1,
+            beta2,
+            beta1_correction,
+            beta2_correction,
+            eps,
+            weight_decay,
+        )
+
+
+def rollback_adamw(
+    g: torch.Tensor, p: torch.Tensor, m: torch.Tensor, v: torch.Tensor,
+    lr,
+    beta1,
+    beta2,
+    beta1_correction,
+    beta2_correction,
+    eps,
+    decay,
+):
+    update = (m / beta1_correction) / ((v / beta2_correction).sqrt() + eps)
+    update.mul_(lr)
+    p.add_(update).div_(1 - lr * decay)
+    v.addcmul_(g, g, value=beta2 - 1).div_(beta2)
+    m.add_(g, alpha=beta1 - 1).div_(beta1)
+
+
+def slice_tensor_list_in_chunks(tensor_list, chunk_size=0):
+    sliced_tensor_list = []
+    
+    for tensor in tensor_list:
+        current_index = 0
+        while current_index < tensor.numel():
+            end = min(current_index + chunk_size, tensor.numel())
+            sliced_tensor_list.append(tensor.view(-1)[current_index:end])
+            current_index += chunk_size
+
+    return sliced_tensor_list

--- a/megatron/spiral/optimizer/optimizer.py
+++ b/megatron/spiral/optimizer/optimizer.py
@@ -5,19 +5,23 @@ from megatron.optimizer.optimizer import MixedPrecisionOptimizer, Float16Optimiz
 from megatron.optimizer.optimizer import _zero_grad_group_helper
 from megatron.spiral.optimizer.cpu_adam import SpiralCPUAdam
 from megatron.spiral.utils import is_spiral_param
+from megatron.spiral.debug import spiral_report_memory
 
 
 class SpiralFloat16Optimizer(MixedPrecisionOptimizer):
 
     @torch.no_grad()
     def step(self, args, timers):
+        spiral_report_memory(f"before step")
         self.optimizer.step()
+        spiral_report_memory(f"after step")
 
     def sync(self, found_inf=None):
         self.optimizer.sync(found_inf)
 
     @torch.no_grad()
     def rollback(self, sync=False):
+        spiral_report_memory(f"before rollback")
         if type(self.optimizer) == SpiralCPUAdam:
             self.optimizer.rollback(sync)
         else:
@@ -32,6 +36,7 @@ class SpiralFloat16Optimizer(MixedPrecisionOptimizer):
                 for p in group['params']:
                     if is_spiral_param(p):
                         p.offload(non_blocking=not sync)
+        spiral_report_memory(f"after rollback")
 
     def zero_grad(self, set_to_none=True):
         for group in self.optimizer.param_groups:
@@ -47,7 +52,9 @@ class SpiralFloat16Optimizer(MixedPrecisionOptimizer):
 class SpiralFP32Optimizer(FP32Optimizer):
     @torch.no_grad()
     def step(self, args, timers):
+        spiral_report_memory(f"before step")
         self.optimizer.step()
+        spiral_report_memory(f"after step")
 
     def sync(self, found_inf=None):
         self.optimizer.sync()


### PR DESCRIPTION
### Feature
- Create new base optimizer named `SpiralGPUChunkedAdam`
- It store optimizer state (fp32 param, momentum, varience) in CPU and fetch before updating parameters and offload afterwards
- Chunk the parameter tensor to `hidden_size^2` to buffer it to constant size

### Exec
```bash
# stage optimizer with CPU
$ sbatch -p spipe -N 1 ./examples/asplos25/run.sh -j spiral -n llama2 -s 1 -f 3 -b 3 -t 30 -l 1 -m 1 -g 8 -o stage
# stage optimizer with CPU + GPU (1st stage)
$ sbatch -p spipe -N 1 ./examples/asplos25/run.sh -j spiral -n llama2 -s 1 -f 3 -b 3 -t 30 -l 1 -m 1 -g 8 -o stage-hetero
# stage optimizer with CPU + state offload GPU (1st stage)
$ sbatch -p spipe -N 1 ./examples/asplos25/run.sh -j spiral -n llama2 -s 1 -f 3 -b 3 -t 30 -l 1 -m 1 -g 8 -o stage-hetero-offload
```