### PR TITLE
Hotfix: resolve hang in spipe multi-node run

### DIFF
--- a/megatron/spiral/schedules/spipe_schedule.py
+++ b/megatron/spiral/schedules/spipe_schedule.py
@@ -188,27 +188,29 @@ def spipe_schedule(
         prefetch_event_queries[prefetch_f0.tag] = prefetch_f0
 
     # pre-pipeline non-compute timesteps
-    # NOTE fwd_pre_pipeline_init_recvs **MUST PRECEDE** pre-pipeline comm_ckpt to avoid deadlock
-    #   e.g., rank 0: a) comm_actv (isend) -> b) comm_ckpt (isend)
-    #         rank 1: b) pre-pipeline comm_ckpt (irecv) -> a) comm_actv (irecv)
-    # Above pattern deadlocks as a)s and b)s requires synchronization, respectively.
-    # Another solution can be to move fwd_pre_pipeline_init_recvs logic into fwd_init_recvs and reorder to
-    # comm_ckpt >> comm_actv/_actv_grad pattern. However, this stall activation sdrvs which are the
-    # critical path for the pipeline. So, we choose to keep comm_actv/_actv_grad >> comm_ckpt pattern and
-    # use current form.
-
-    # set the first input tensor of pprank != 0 ranks
-    fwd_pre_pipeline_init_recvs(
-        recvs,
-        dtype,
-        tensor_shape,
-        overlap_p2p_comm=overlap_p2p_comm,
-        batch_p2p_comm=batch_p2p_comm,
-        timers=timers,
-    )
-    # must succeed `fwd_pre_pipeline_init_recvs` to avoid deadlock
     __num_pre_pipeline_non_compute_ts = mpu.get_pipeline_model_parallel_rank()
-    for _ in range(__num_pre_pipeline_non_compute_ts):
+    for ppnct in range(__num_pre_pipeline_non_compute_ts):
+        if ppnct == __num_pre_pipeline_non_compute_ts - 1:
+            # NOTE In the last non_compute timestep, fwd_pre_pipeline_init_recvs **MUST PRECEDE** pre-pipeline
+            # comm_ckpt to avoid deadlock.
+            #   e.g., rank 0: a) comm_actv (isend) -> b) comm_ckpt (isend)
+            #         rank 1: b) pre-pipeline comm_ckpt (irecv) -> a) comm_actv (irecv)
+            # Above pattern deadlocks as a)s and b)s requires synchronization, respectively.
+            # Another solution can be to move fwd_pre_pipeline_init_recvs logic into fwd_init_recvs and reorder to
+            # comm_ckpt >> comm_actv/_actv_grad pattern. However, this stall activation sdrvs which are the
+            # critical path for the pipeline. So, we choose to keep comm_actv/_actv_grad >> comm_ckpt pattern and
+            # use current form.
+            # NOTE Moving this out of current for loop, or merging with fwd_init_recvs in the fwd for loop will
+            # definitely lead to deadlock.
+            fwd_pre_pipeline_init_recvs(
+                recvs,
+                dtype,
+                tensor_shape,
+                overlap_p2p_comm=overlap_p2p_comm,
+                batch_p2p_comm=batch_p2p_comm,
+                timers=timers,
+            )
+        # endif
         if not forward_only:
             comm_ckpt(
                 next(ckpt_send_recv_schedule),


### PR DESCRIPTION
Pre-pipeline as-is:

1. fwd_pre_pipeline_init_recvs: first forward stage의 microbatch 0의 input activation 받는다
2. num_non_compute_ts 동안 comm_ckpt (if any) 를 한다.

→ 문제: 1의 handshake가 이뤄지기 전까지 2의 call은 모두 stall된다. Inter-node boundary에서, hang을 유발하는 것으로 보임.

Now:
```
for num_non_compute_ts:
  if last non compute ts:
     first forward stage의 microbatch 0의 input activation 받는다
  comm_ckpt를 한다.
```

Result
Any spipe run with two nodes should have hung before. Now there is no hang. For instance, below command works.
 
```
sbatch -J spipe -p spipe -N 2 ./examples/asplos25/run.sh -j spiral -n llama2 -s 13 -f 4 -b 4 -t 10 -l 1 -m 1 -g 32
```