### PR TITLE
Add option for using p2p ops comm. for actv

### DIFF
--- a/examples/asplos25/args.sh
+++ b/examples/asplos25/args.sh
@@ -4,17 +4,12 @@
 export MASTER_ADDR=$(echo $UNWRAPPED_NODELIST | awk '{print $1}')
 export MASTER_PORT=$(comm -23 <(seq 10000 65535 | sort) <(ss -tan | awk '{print $4}' | cut -d':' -f2 | grep -v '^\s*$' | sort -u) | shuf -n 1)
 export CUDA_DEVICE_MAX_CONNECTIONS=1
-# export TORCH_NCCL_USE_COMM_NONBLOCKING=1
-# export NCCL_DEBUG=INFO
-# export NCCL_DEBUG_SUBSYS=ALL
-# export TORCH_DISTRIBUTED_DEBUG=INFO
 
 DISTRIBUTED_ARGS="
     --tensor-model-parallel-size 1 \
     --distributed-backend nccl \
     --master-addr $MASTER_ADDR \
-    --master-port $MASTER_PORT \
-    --distributed-timeout-minutes 1
+    --master-port $MASTER_PORT
 "
 if [[ $NO_PIPELINE_PARALLEL -eq 1 ]]; then
     DISTRIBUTED_ARGS="
@@ -33,8 +28,7 @@ DATA_ARGS="
     --vocab-file $VOCAB_FILE \
     --merge-file $MERGE_FILE \
     --data-impl mmap \
-    --split 949,50,1 \
-    --num-workers 0
+    --split 949,50,1
 "
 
 MIXED_PRECISION_ARGS="

--- a/examples/asplos25/args.sh
+++ b/examples/asplos25/args.sh
@@ -4,12 +4,17 @@
 export MASTER_ADDR=$(echo $UNWRAPPED_NODELIST | awk '{print $1}')
 export MASTER_PORT=$(comm -23 <(seq 10000 65535 | sort) <(ss -tan | awk '{print $4}' | cut -d':' -f2 | grep -v '^\s*$' | sort -u) | shuf -n 1)
 export CUDA_DEVICE_MAX_CONNECTIONS=1
+# export TORCH_NCCL_USE_COMM_NONBLOCKING=1
+# export NCCL_DEBUG=INFO
+# export NCCL_DEBUG_SUBSYS=ALL
+# export TORCH_DISTRIBUTED_DEBUG=INFO
 
 DISTRIBUTED_ARGS="
     --tensor-model-parallel-size 1 \
     --distributed-backend nccl \
     --master-addr $MASTER_ADDR \
-    --master-port $MASTER_PORT
+    --master-port $MASTER_PORT \
+    --distributed-timeout-minutes 1
 "
 if [[ $NO_PIPELINE_PARALLEL -eq 1 ]]; then
     DISTRIBUTED_ARGS="
@@ -28,7 +33,8 @@ DATA_ARGS="
     --vocab-file $VOCAB_FILE \
     --merge-file $MERGE_FILE \
     --data-impl mmap \
-    --split 949,50,1
+    --split 949,50,1 \
+    --num-workers 0
 "
 
 MIXED_PRECISION_ARGS="

--- a/examples/asplos25/config.sh
+++ b/examples/asplos25/config.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-while getopts "j:n:s:t:l:f:b:m:g:o:v:w:x:y:z:" opt
+while getopts "j:n:s:t:l:f:b:m:g:o:v:x:y:" opt
 do
     case "$opt" in
         j ) JOB_TYPE="$OPTARG" ;;
@@ -14,10 +14,8 @@ do
         g ) GBS="$OPTARG" ;;
         o ) OPTIMIZER="$OPTARG" ;;
         v ) ACTV_P2P="$OPTARG" ;;
-        w ) INIT_LOSS_SCALE="$OPTARG" ;;
         x ) CROSS_MAPPING="$OPTARG" ;;
         y ) SYNC_CKPT_COMMUNICATION="$OPTARG" ;;
-        z ) SEQ="$OPTARG" ;;
     esac
 done
 
@@ -69,9 +67,6 @@ JOB_NAME=${JOB_NAME:="opt"}
 MBS=${MBS:=1}
 GBS=${GBS:=$(( $MBS * $NP ))}
 
-# Sequence length
-SEQ=${SEQ:=4096}
-
 # iteration
 TRAIN_ITER=${TRAIN_ITER:=100}
 LOG_ITER=${LOG_ITER:=10}
@@ -82,8 +77,7 @@ EVAL_ITER=0
 SPIRAL_FWD=${FWD_STAGE:=2}
 SPIRAL_BWD=${BWD_STAGE:=2}
 SPIRAL_SHMEM_NAME=/spiral-${USER}
-SPIRAL_SHMEM_BUFFER_SIZE=${SHMEM_BUFFER_SIZE:=$(( 32 * 2**30 ))}
-# SPIRAL_SHMEM_BUFFER_SIZE=${SHMEM_BUFFER_SIZE:=$(( 4 * 2**30 ))}
+SPIRAL_SHMEM_BUFFER_SIZE=${SHMEM_BUFFER_SIZE:=$(( 64 * 2**30 ))}
 SPIRAL_SHMEM_HEADER_SIZE=$(( 1 * 2**30 ))
 SPIRAL_DEBUG_BACKEND=NO
 

--- a/examples/asplos25/config.sh
+++ b/examples/asplos25/config.sh
@@ -108,9 +108,9 @@ else
 fi
 
 if [[ "$ACTV_P2P" == "1" ]]; then
-    SPIRAL_P2P=YES
+    SPIRAL_ACTV_P2P=YES
 else
-    SPIRAL_P2P=NO
+    SPIRAL_ACTV_P2P=NO
 fi
 
 # config for interleaving

--- a/examples/asplos25/config.sh
+++ b/examples/asplos25/config.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-while getopts "j:n:s:t:l:f:b:m:g:o:x:y:" opt
+while getopts "j:n:s:t:l:f:b:m:g:o:v:x:y:" opt
 do
     case "$opt" in
         j ) JOB_TYPE="$OPTARG" ;;
@@ -13,6 +13,7 @@ do
         m ) MBS="$OPTARG" ;;
         g ) GBS="$OPTARG" ;;
         o ) OPTIMIZER="$OPTARG" ;;
+        v ) ACTV_P2P="$OPTARG" ;;
         x ) CROSS_MAPPING="$OPTARG" ;;
         y ) SYNC_CKPT_COMMUNICATION="$OPTARG" ;;
     esac
@@ -104,6 +105,12 @@ if [[ "$SYNC_CKPT_COMMUNICATION" == "1" ]]; then
     SPIRAL_SYNC_CKPT_COMMUNICATION=YES
 else
     SPIRAL_SYNC_CKPT_COMMUNICATION=NO
+fi
+
+if [[ "$ACTV_P2P" == "1" ]]; then
+    SPIRAL_P2P=YES
+else
+    SPIRAL_P2P=NO
 fi
 
 # config for interleaving

--- a/examples/asplos25/config.sh
+++ b/examples/asplos25/config.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-while getopts "j:n:s:t:l:f:b:m:g:o:v:x:y:" opt
+while getopts "j:n:s:t:l:f:b:m:g:o:v:w:x:y:z:" opt
 do
     case "$opt" in
         j ) JOB_TYPE="$OPTARG" ;;
@@ -14,8 +14,10 @@ do
         g ) GBS="$OPTARG" ;;
         o ) OPTIMIZER="$OPTARG" ;;
         v ) ACTV_P2P="$OPTARG" ;;
+        w ) INIT_LOSS_SCALE="$OPTARG" ;;
         x ) CROSS_MAPPING="$OPTARG" ;;
         y ) SYNC_CKPT_COMMUNICATION="$OPTARG" ;;
+        z ) SEQ="$OPTARG" ;;
     esac
 done
 
@@ -67,6 +69,9 @@ JOB_NAME=${JOB_NAME:="opt"}
 MBS=${MBS:=1}
 GBS=${GBS:=$(( $MBS * $NP ))}
 
+# Sequence length
+SEQ=${SEQ:=4096}
+
 # iteration
 TRAIN_ITER=${TRAIN_ITER:=100}
 LOG_ITER=${LOG_ITER:=10}
@@ -77,7 +82,8 @@ EVAL_ITER=0
 SPIRAL_FWD=${FWD_STAGE:=2}
 SPIRAL_BWD=${BWD_STAGE:=2}
 SPIRAL_SHMEM_NAME=/spiral-${USER}
-SPIRAL_SHMEM_BUFFER_SIZE=${SHMEM_BUFFER_SIZE:=$(( 64 * 2**30 ))}
+SPIRAL_SHMEM_BUFFER_SIZE=${SHMEM_BUFFER_SIZE:=$(( 32 * 2**30 ))}
+# SPIRAL_SHMEM_BUFFER_SIZE=${SHMEM_BUFFER_SIZE:=$(( 4 * 2**30 ))}
 SPIRAL_SHMEM_HEADER_SIZE=$(( 1 * 2**30 ))
 SPIRAL_DEBUG_BACKEND=NO
 
@@ -122,6 +128,7 @@ echo -e "JOB_TYPE=${JOB_TYPE}\nJOB_NAME=${JOB_NAME}\nHOSTS=${HOSTS}\nNSYS_ENABLE
 echo -e "MODEL_SIZE=${MODEL_SIZE}\nMBS=${MBS}\nGBS=${GBS}"
 echo -e "TRAIN_ITER=${TRAIN_ITER}\nLOG_ITER=${LOG_ITER}(skip0=${SKIP_TRAIN_ITER_ZERO_TIMING})\nEVAL_ITER=${EVAL_ITER}"
 echo -e "SPIRAL_STAGE_OPTIMIZER=${SPIRAL_STAGE_OPTIMIZER}"
+echo -e "SPIRAL_ACTV_P2P=${SPIRAL_ACTV_P2P}"
 echo -e "SPIRAL_CROSS_MAPPING=${SPIRAL_CROSS_MAPPING}"
 echo -e "SPIRAL_SYNC_CKPT_COMMUNICATION=${SPIRAL_SYNC_CKPT_COMMUNICATION}"
 echo -e "SPIRAL_FWD=${SPIRAL_FWD}\nSPIRAL_BWD=${SPIRAL_BWD}"

--- a/examples/asplos25/extra_args/mobius.sh
+++ b/examples/asplos25/extra_args/mobius.sh
@@ -29,3 +29,7 @@ fi
 if [ ${SPIRAL_OFFLOAD_OPTIMIZER} == "YES" ]; then
     EXTRA_ARGS+=" --spiral-offload-optimizer"
 fi
+
+if [ ${SPIRAL_ACTV_P2P} == "YES" ]; then
+    EXTRA_ARGS+=" --spiral-actv-p2p"
+fi

--- a/examples/asplos25/extra_args/spiral.sh
+++ b/examples/asplos25/extra_args/spiral.sh
@@ -40,3 +40,7 @@ fi
 if [ ${SPIRAL_SYNC_CKPT_COMMUNICATION} == "YES" ]; then
     EXTRA_ARGS+=" --spiral-sync-ckpt-communication"
 fi
+
+if [ ${SPIRAL_P2P} == "YES" ]; then
+    EXTRA_ARGS+=" --spiral-p2p"
+fi

--- a/examples/asplos25/extra_args/spiral.sh
+++ b/examples/asplos25/extra_args/spiral.sh
@@ -41,6 +41,6 @@ if [ ${SPIRAL_SYNC_CKPT_COMMUNICATION} == "YES" ]; then
     EXTRA_ARGS+=" --spiral-sync-ckpt-communication"
 fi
 
-if [ ${SPIRAL_P2P} == "YES" ]; then
-    EXTRA_ARGS+=" --spiral-p2p"
+if [ ${SPIRAL_ACTV_P2P} == "YES" ]; then
+    EXTRA_ARGS+=" --spiral-actv-p2p"
 fi

--- a/megatron/arguments.py
+++ b/megatron/arguments.py
@@ -1144,6 +1144,8 @@ def _add_distributed_args(parser):
     group.add_argument('--spiral-sync-ckpt-communication', action='store_true',
                         help='Disable SpiralPipe asynchronous checkpoint communication. Asynchronous '
                         'checkpoint communication typically improves performance by overlapping transmission')
+    group.add_argument('--spiral-p2p', action='store_true',
+                        help='Enable SpiralPipe p2p activation communication')
 
     return parser
 

--- a/megatron/arguments.py
+++ b/megatron/arguments.py
@@ -1144,7 +1144,7 @@ def _add_distributed_args(parser):
     group.add_argument('--spiral-sync-ckpt-communication', action='store_true',
                         help='Disable SpiralPipe asynchronous checkpoint communication. Asynchronous '
                         'checkpoint communication typically improves performance by overlapping transmission')
-    group.add_argument('--spiral-p2p', action='store_true',
+    group.add_argument('--spiral-actv-p2p', action='store_true',
                         help='Enable SpiralPipe p2p activation communication')
 
     return parser

--- a/megatron/spiral/p2p_communication.py
+++ b/megatron/spiral/p2p_communication.py
@@ -24,7 +24,10 @@ def _batched_p2p_ops(
     send_ranks: Optional[List[int]],
     recv_ranks: Optional[List[int]],
     group: torch.distributed.ProcessGroup,
+    omit_send_reqs: bool = False,
 ):
+    assert omit_send_reqs is False, "Batch p2p does not support omitting send reqs"
+
     ops = []
     if tensor_sends is not None:
         assert send_ranks is not None and len(tensor_sends) == len(send_ranks)
@@ -54,14 +57,18 @@ def _p2p_ops(
     send_ranks: Optional[List[int]],
     recv_ranks: Optional[List[int]],
     group: torch.distributed.ProcessGroup,
+    omit_send_reqs: bool = False,
 ):
+    # Send reqs can be omitted to avoid waiting on them
+
     reqs = []
     if mpu.get_pipeline_model_parallel_rank() % 2 == 0:
         if tensor_sends is not None:
             assert send_ranks is not None and len(tensor_sends) == len(send_ranks)
             for tensor, rank in zip(tensor_sends, send_ranks):
                 send_req = torch.distributed.isend(tensor, rank, group=group)
-                reqs.append(send_req)
+                if not omit_send_reqs:
+                    reqs.append(send_req)
         if tensor_recvs is not None:
             assert recv_ranks is not None and len(tensor_recvs) == len(recv_ranks)
             for tensor, rank in zip(tensor_recvs, recv_ranks):
@@ -77,7 +84,8 @@ def _p2p_ops(
             assert send_ranks is not None and len(tensor_sends) == len(send_ranks)
             for tensor, rank in zip(tensor_sends, send_ranks):
                 send_req = torch.distributed.isend(tensor, rank, group=group)
-                reqs.append(send_req)
+                if not omit_send_reqs:
+                    reqs.append(send_req)
     return reqs
 
 
@@ -93,6 +101,7 @@ def _communicate(
     dtype: Optional[torch.dtype],
     variable_seq_lengths: bool = False,
     use_ring_exchange_p2p: bool = False,
+    omit_send_reqs: bool = False,
 ) -> Tuple[Optional[List[torch.Tensor]], Optional[List[Work]]]:
 
     # Create placeholder for receive if needed
@@ -151,6 +160,7 @@ def _communicate(
         send_ranks=send_ranks,
         recv_ranks=recv_ranks,
         group=group if group is not None else mpu.get_pipeline_model_parallel_group(),
+        omit_send_reqs=omit_send_reqs,
     )
 
     if wait_on_reqs and len(reqs) > 0:
@@ -173,6 +183,7 @@ def send_next_recv_prev(
     overlap_p2p_comm: bool = False,
     batch_p2p_comm: bool = True,
     timers: Callable = None,
+    omit_send_reqs: bool = False,
 ) -> Tuple[torch.Tensor, Optional[List[Work]]]:
     if _DEBUG_COMM:
         spiral_print("snrp")
@@ -187,6 +198,7 @@ def send_next_recv_prev(
         wait_on_reqs=not overlap_p2p_comm,
         batch_p2p_comm=batch_p2p_comm,
         dtype=dtype,
+        omit_send_reqs=omit_send_reqs,
     )
     if timers is not None:
         timers("send_next_recv_prev").stop()
@@ -201,6 +213,7 @@ def send_prev_recv_next(
     overlap_p2p_comm: bool = False,
     batch_p2p_comm: bool = True,
     timers: Callable = None,
+    omit_send_reqs: bool = False,
 ) -> Tuple[torch.Tensor, Optional[List[Work]]]:
     if _DEBUG_COMM:
         spiral_print("sprn")
@@ -215,6 +228,7 @@ def send_prev_recv_next(
         wait_on_reqs=not overlap_p2p_comm,
         batch_p2p_comm=batch_p2p_comm,
         dtype=dtype,
+        omit_send_reqs=omit_send_reqs,
     )
     if timers is not None:
         timers("send_next_recv_prev").stop()
@@ -227,6 +241,7 @@ def send_next(
     overlap_p2p_comm: bool = False,
     batch_p2p_comm: bool = True,
     timers: Callable = None,
+    omit_send_reqs: bool = False,
 ) -> Optional[Work]:
     if _DEBUG_COMM:
         spiral_print("sn")
@@ -241,6 +256,7 @@ def send_next(
         wait_on_reqs=not overlap_p2p_comm,
         batch_p2p_comm=batch_p2p_comm,
         dtype=None,
+        omit_send_reqs=omit_send_reqs,
     )
     if timers is not None:
         timers("send_next").stop()
@@ -280,6 +296,7 @@ def send_prev(
     overlap_p2p_comm: bool = False,
     batch_p2p_comm: bool = True,
     timers: Callable = None,
+    omit_send_reqs: bool = False,
 ) -> Optional[Work]:
     if _DEBUG_COMM:
         spiral_print("sp")
@@ -294,6 +311,7 @@ def send_prev(
         wait_on_reqs=not overlap_p2p_comm,
         batch_p2p_comm=batch_p2p_comm,
         dtype=None,
+        omit_send_reqs=omit_send_reqs,
     )
     if timers is not None:
         timers("send_next").stop()

--- a/megatron/spiral/schedules/mobius_communication.py
+++ b/megatron/spiral/schedules/mobius_communication.py
@@ -39,6 +39,7 @@ def comm_activation(
     overlap_p2p_comm: bool = False,
     batch_p2p_comm: bool = False,
     timers: Callable = None,
+    omit_send_reqs: bool = False,
 ):
     """Communicate activation.
 
@@ -98,6 +99,7 @@ def comm_activation(
             overlap_p2p_comm=overlap_p2p_comm,
             batch_p2p_comm=batch_p2p_comm,
             timers=timers,
+            omit_send_reqs=omit_send_reqs,
         )
     elif case_color == CaseColor.Red:
         recv, reqs = spiral_p2p.recv_prev(
@@ -116,6 +118,7 @@ def comm_activation(
             overlap_p2p_comm=overlap_p2p_comm,
             batch_p2p_comm=batch_p2p_comm,
             timers=timers,
+            omit_send_reqs=omit_send_reqs,
         )
         recvs.append((recv, reqs))
     else:
@@ -134,6 +137,7 @@ def comm_activation_grad(
     overlap_p2p_comm: bool = False,
     batch_p2p_comm: bool = False,
     timers: Callable = None,
+    omit_send_reqs: bool = False,
 ):
     """Communicate activation gradients.
 
@@ -192,6 +196,7 @@ def comm_activation_grad(
             overlap_p2p_comm=overlap_p2p_comm,
             batch_p2p_comm=batch_p2p_comm,
             timers=timers,
+            omit_send_reqs=omit_send_reqs,
         )
     elif case_color == CaseColor.Red:
         recv, reqs = spiral_p2p.recv_next(
@@ -210,6 +215,7 @@ def comm_activation_grad(
             overlap_p2p_comm=overlap_p2p_comm,
             batch_p2p_comm=batch_p2p_comm,
             timers=timers,
+            omit_send_reqs=omit_send_reqs,
         )
         recvs.append((recv, reqs))
     else:

--- a/megatron/spiral/schedules/mobius_schedule.py
+++ b/megatron/spiral/schedules/mobius_schedule.py
@@ -333,6 +333,7 @@ def mobius_schedule(
                 overlap_p2p_comm=overlap_p2p_comm,
                 batch_p2p_comm=batch_p2p_comm,
                 timers=timers,
+                omit_send_reqs=not batch_p2p_comm,
             )
 
             torch.cuda.nvtx.range_pop()
@@ -516,6 +517,7 @@ def mobius_schedule(
                 overlap_p2p_comm=overlap_p2p_comm,
                 batch_p2p_comm=batch_p2p_comm,
                 timers=timers,
+                omit_send_reqs=not batch_p2p_comm,
             )
 
             torch.cuda.nvtx.range_pop()

--- a/megatron/spiral/schedules/spipe_communication.py
+++ b/megatron/spiral/schedules/spipe_communication.py
@@ -29,6 +29,7 @@ def comm_activation(
     overlap_p2p_comm: bool = False,
     batch_p2p_comm: bool = False,
     timers: Callable = None,
+    omit_send_reqs: bool = False,
 ):
     """Communicate activation.
 
@@ -61,6 +62,7 @@ def comm_activation(
             overlap_p2p_comm=overlap_p2p_comm,
             batch_p2p_comm=batch_p2p_comm,
             timers=timers,
+            omit_send_reqs=omit_send_reqs,
         )
     else:
         recv, reqs = spiral_p2p.send_next_recv_prev(
@@ -70,6 +72,7 @@ def comm_activation(
             overlap_p2p_comm=overlap_p2p_comm,
             batch_p2p_comm=batch_p2p_comm,
             timers=timers,
+            omit_send_reqs=omit_send_reqs,
         )
         recvs.append((recv, reqs))
 
@@ -85,6 +88,7 @@ def comm_activation_grad(
     overlap_p2p_comm: bool = False,
     batch_p2p_comm: bool = False,
     timers: Callable = None,
+    omit_send_reqs: bool = False,
 ):
     """Communicate activation gradients.
 
@@ -117,6 +121,7 @@ def comm_activation_grad(
             overlap_p2p_comm=overlap_p2p_comm,
             batch_p2p_comm=batch_p2p_comm,
             timers=timers,
+            omit_send_reqs=omit_send_reqs,
         )
     else:
         recv, reqs = spiral_p2p.send_next_recv_prev(
@@ -126,6 +131,7 @@ def comm_activation_grad(
             overlap_p2p_comm=overlap_p2p_comm,
             batch_p2p_comm=batch_p2p_comm,
             timers=timers,
+            omit_send_reqs=omit_send_reqs,
         )
         recvs.append((recv, reqs))
 

--- a/megatron/spiral/schedules/spipe_schedule.py
+++ b/megatron/spiral/schedules/spipe_schedule.py
@@ -31,7 +31,7 @@ Shape = Union[List[int], torch.Size]
 
 # Constants
 _DEBUG_SCHEDULE = True
-
+_USE_BATCH_P2P_COMM = False
 
 def spipe_schedule(
     *,
@@ -207,7 +207,7 @@ def spipe_schedule(
                 dtype,
                 tensor_shape,
                 overlap_p2p_comm=overlap_p2p_comm,
-                batch_p2p_comm=batch_p2p_comm,
+                batch_p2p_comm=_USE_BATCH_P2P_COMM,
                 timers=timers,
             )
         # endif
@@ -338,8 +338,9 @@ def spipe_schedule(
                 tensor_shape,
                 dtype,
                 overlap_p2p_comm=overlap_p2p_comm,
-                batch_p2p_comm=batch_p2p_comm,
+                batch_p2p_comm=_USE_BATCH_P2P_COMM,
                 timers=timers,
+                omit_send_reqs=not _USE_BATCH_P2P_COMM,
             )
             # sdrv ckpt
             if not forward_only:
@@ -518,8 +519,9 @@ def spipe_schedule(
                 tensor_shape,
                 dtype,
                 overlap_p2p_comm=overlap_p2p_comm,
-                batch_p2p_comm=batch_p2p_comm,
+                batch_p2p_comm=_USE_BATCH_P2P_COMM,
                 timers=timers,
+                omit_send_reqs=not _USE_BATCH_P2P_COMM,
             )
             # sdrv ckpt
             comm_ckpt(

--- a/megatron/spiral/schedules/spipe_schedule.py
+++ b/megatron/spiral/schedules/spipe_schedule.py
@@ -32,6 +32,7 @@ Shape = Union[List[int], torch.Size]
 # Constants
 _DEBUG_SCHEDULE = True
 
+
 def spipe_schedule(
     *,
     forward_step_func,

--- a/megatron/spiral/schedules/spipe_schedule.py
+++ b/megatron/spiral/schedules/spipe_schedule.py
@@ -31,7 +31,6 @@ Shape = Union[List[int], torch.Size]
 
 # Constants
 _DEBUG_SCHEDULE = True
-_USE_BATCH_P2P_COMM = False
 
 def spipe_schedule(
     *,
@@ -123,6 +122,8 @@ def spipe_schedule(
             "Spiral is not supported with a different decoder sequence length."
         )
 
+    use_batch_p2p_comm = not get_args().spiral_p2p
+
     offload_grad_after_bwd_stage = get_args().spiral_overlap_offload_grad
     optimize_after_bwd_stage = offload_grad_after_bwd_stage and get_args().spiral_stage_optimizer
     if get_args().spiral_stage_optimizer:
@@ -207,7 +208,7 @@ def spipe_schedule(
                 dtype,
                 tensor_shape,
                 overlap_p2p_comm=overlap_p2p_comm,
-                batch_p2p_comm=_USE_BATCH_P2P_COMM,
+                batch_p2p_comm=use_batch_p2p_comm,
                 timers=timers,
             )
         # endif
@@ -338,9 +339,9 @@ def spipe_schedule(
                 tensor_shape,
                 dtype,
                 overlap_p2p_comm=overlap_p2p_comm,
-                batch_p2p_comm=_USE_BATCH_P2P_COMM,
+                batch_p2p_comm=use_batch_p2p_comm,
                 timers=timers,
-                omit_send_reqs=not _USE_BATCH_P2P_COMM,
+                omit_send_reqs=not use_batch_p2p_comm,
             )
             # sdrv ckpt
             if not forward_only:
@@ -519,9 +520,9 @@ def spipe_schedule(
                 tensor_shape,
                 dtype,
                 overlap_p2p_comm=overlap_p2p_comm,
-                batch_p2p_comm=_USE_BATCH_P2P_COMM,
+                batch_p2p_comm=use_batch_p2p_comm,
                 timers=timers,
-                omit_send_reqs=not _USE_BATCH_P2P_COMM,
+                omit_send_reqs=not use_batch_p2p_comm,
             )
             # sdrv ckpt
             comm_ckpt(

--- a/megatron/spiral/schedules/spipe_schedule.py
+++ b/megatron/spiral/schedules/spipe_schedule.py
@@ -122,7 +122,7 @@ def spipe_schedule(
             "Spiral is not supported with a different decoder sequence length."
         )
 
-    use_batch_p2p_comm = not get_args().spiral_p2p
+    use_batch_p2p_comm = not get_args().spiral_actv_p2p
 
     offload_grad_after_bwd_stage = get_args().spiral_overlap_offload_grad
     optimize_after_bwd_stage = offload_grad_after_bwd_stage and get_args().spiral_stage_optimizer

--- a/megatron/spiral/schedules/spipe_schedule.py
+++ b/megatron/spiral/schedules/spipe_schedule.py
@@ -122,8 +122,6 @@ def spipe_schedule(
             "Spiral is not supported with a different decoder sequence length."
         )
 
-    use_batch_p2p_comm = not get_args().spiral_actv_p2p
-
     offload_grad_after_bwd_stage = get_args().spiral_overlap_offload_grad
     optimize_after_bwd_stage = offload_grad_after_bwd_stage and get_args().spiral_stage_optimizer
     if get_args().spiral_stage_optimizer:
@@ -208,7 +206,7 @@ def spipe_schedule(
                 dtype,
                 tensor_shape,
                 overlap_p2p_comm=overlap_p2p_comm,
-                batch_p2p_comm=use_batch_p2p_comm,
+                batch_p2p_comm=batch_p2p_comm,
                 timers=timers,
             )
         # endif
@@ -339,9 +337,9 @@ def spipe_schedule(
                 tensor_shape,
                 dtype,
                 overlap_p2p_comm=overlap_p2p_comm,
-                batch_p2p_comm=use_batch_p2p_comm,
+                batch_p2p_comm=batch_p2p_comm,
                 timers=timers,
-                omit_send_reqs=not use_batch_p2p_comm,
+                omit_send_reqs=not batch_p2p_comm,
             )
             # sdrv ckpt
             if not forward_only:
@@ -520,9 +518,9 @@ def spipe_schedule(
                 tensor_shape,
                 dtype,
                 overlap_p2p_comm=overlap_p2p_comm,
-                batch_p2p_comm=use_batch_p2p_comm,
+                batch_p2p_comm=batch_p2p_comm,
                 timers=timers,
-                omit_send_reqs=not use_batch_p2p_comm,
+                omit_send_reqs=not batch_p2p_comm,
             )
             # sdrv ckpt
             comm_ckpt(

--- a/megatron/training.py
+++ b/megatron/training.py
@@ -840,7 +840,7 @@ def train_step(forward_step_func, data_iterator,
         grad_scaler=getattr(optimizer, "scale_loss", None),
         sequence_parallel=args.sequence_parallel,
         overlap_p2p_comm=args.overlap_p2p_comm,
-        batch_p2p_comm=not args.overlap_p2p_comm and not args.spiral_actv_p2p,
+        batch_p2p_comm=not args.overlap_p2p_comm or not args.spiral_actv_p2p,
         forward_only=False,
         timers=fwd_bwd_timers,
         **kwargs)

--- a/megatron/training.py
+++ b/megatron/training.py
@@ -840,7 +840,7 @@ def train_step(forward_step_func, data_iterator,
         grad_scaler=getattr(optimizer, "scale_loss", None),
         sequence_parallel=args.sequence_parallel,
         overlap_p2p_comm=args.overlap_p2p_comm,
-        batch_p2p_comm=not args.overlap_p2p_comm,
+        batch_p2p_comm=not args.overlap_p2p_comm and not args.spiral_actv_p2p,
         forward_only=False,
         timers=fwd_bwd_timers,
         **kwargs)


### PR DESCRIPTION
Current activation sdrv relies on batch_p2p (when `overlap_p2p` option is given).
This makes wait on its handle to also wait for isend, which is not necessary.
This PR removes such behavior, only blocking on the wait() for the irecv handle of activation communication. 

This commit is rebased on top of PR #48. Please merge 48 first and then this.