### PR TITLE
fix megatron lock file error

### DIFF
--- a/examples/asplos25/run.sh
+++ b/examples/asplos25/run.sh
@@ -31,17 +31,9 @@ if [ -n "$FUSED_KERNEL_LOCK" ] && [ -f "${FUSED_KERNEL_LOCK}" ]; then
     rm "${FUSED_KERNEL_LOCK}" 2>/dev/null || true # Ignore timing issue
 fi
 
-# Remove spiral shmem file
 if [ -n "${SPIRAL_SHMEM_NAME}" ] && [ -e "/dev/shm${SPIRAL_SHMEM_NAME}" ]; then
     if [ ! -r "/dev/shm${SPIRAL_SHMEM_NAME}" ] || [ ! -w "/dev/shm${SPIRAL_SHMEM_NAME}" ]; then
         echo "Permission error: /dev/shm${SPIRAL_SHMEM_NAME} exists already and is not readable/writable"
-        exit 1
-    fi
-    rm "/dev/shm${SPIRAL_SHMEM_NAME}" 2>/dev/null
-    if [ ! -f "/dev/shm${SPIRAL_SHMEM_NAME}" ]; then
-        echo "Successfully removed /dev/shm${SPIRAL_SHMEM_NAME}."
-    else
-        echo "Failed to remove /dev/shm${SPIRAL_SHMEM_NAME}. Exiting."
         exit 1
     fi
 fi

--- a/examples/asplos25/run.sh
+++ b/examples/asplos25/run.sh
@@ -28,13 +28,20 @@ fi
 
 # Remove Megatron lockfile
 if [ -n "$FUSED_KERNEL_LOCK" ] && [ -f "${FUSED_KERNEL_LOCK}" ]; then
-    rm ${FUSED_KERNEL_LOCK}
+    rm "${FUSED_KERNEL_LOCK}" 2>/dev/null || true # Ignore timing issue
 fi
 
 # Remove spiral shmem file
 if [ -n "${SPIRAL_SHMEM_NAME}" ] && [ -e "/dev/shm${SPIRAL_SHMEM_NAME}" ]; then
     if [ ! -r "/dev/shm${SPIRAL_SHMEM_NAME}" ] || [ ! -w "/dev/shm${SPIRAL_SHMEM_NAME}" ]; then
         echo "Permission error: /dev/shm${SPIRAL_SHMEM_NAME} exists already and is not readable/writable"
+        exit 1
+    fi
+    rm "/dev/shm${SPIRAL_SHMEM_NAME}" 2>/dev/null
+    if [ ! -f "/dev/shm${SPIRAL_SHMEM_NAME}" ]; then
+        echo "Successfully removed /dev/shm${SPIRAL_SHMEM_NAME}."
+    else
+        echo "Failed to remove /dev/shm${SPIRAL_SHMEM_NAME}. Exiting."
         exit 1
     fi
 fi


### PR DESCRIPTION
- fused kernel lock may be absent when trying to `rm`, when other job launched at the very similar timing already removed it. Silence the error from such timing issue and refrain from exiting due to it.