### PR TITLE
Bind numa node to process and set affinity to pt_main_thread

### DIFF
--- a/csrc/common/util.hpp
+++ b/csrc/common/util.hpp
@@ -59,31 +59,20 @@
     }                                                                          \
   } while (0)
 
-void set_affinity(const std::vector<int>& excluded_cpus = {}) {
+void set_cpu_affinity(const std::vector<int> &cpu_affinity = {})
+{
+  // By default, assign the CPU affinity of the main thread
+  if (cpu_affinity.empty()){
+    return;
+  }
+
   cpu_set_t cpu_set;
   CPU_ZERO(&cpu_set);
-
-  for (int i = 0; i < CPU_SETSIZE; ++i) {
-    if (std::find(excluded_cpus.begin(), excluded_cpus.end(), i) == excluded_cpus.end()) {
-      CPU_SET(i, &cpu_set);
+  for (int cpu_id : cpu_affinity){
+    if (cpu_id >= 0 && cpu_id < CPU_SETSIZE) {
+      CPU_SET(cpu_id, &cpu_set); // Add this CPU to the set
     }
   }
 
   assert(sched_setaffinity(0, sizeof(cpu_set_t), &cpu_set) == 0);
-}
-
-std::vector<int> get_affinity() {
-  std::vector<int> cpu_affinity;
-
-  cpu_set_t cpu_set;
-  CPU_ZERO(&cpu_set);
-  assert(sched_getaffinity(0, sizeof(cpu_set_t), &cpu_set) == 0);
-
-  for (int i = 0; i < CPU_SETSIZE; ++i) {
-    if (CPU_ISSET(i, &cpu_set)) {
-      cpu_affinity.push_back(i);
-    }
-  }
-
-  return cpu_affinity;
 }

--- a/csrc/common/util.hpp
+++ b/csrc/common/util.hpp
@@ -1,9 +1,6 @@
 #pragma once
 
 #include <cassert>
-#include <vector>
-#include <algorithm>
-#include <sched.h>
 
 #define CHECK_CUDA(call)                                                       \
   do {                                                                         \
@@ -58,21 +55,3 @@
       assert(false);                                                           \
     }                                                                          \
   } while (0)
-
-void set_cpu_affinity(const std::vector<int> &cpu_affinity = {})
-{
-  // By default, assign the CPU affinity of the main thread
-  if (cpu_affinity.empty()){
-    return;
-  }
-
-  cpu_set_t cpu_set;
-  CPU_ZERO(&cpu_set);
-  for (int cpu_id : cpu_affinity){
-    if (cpu_id >= 0 && cpu_id < CPU_SETSIZE) {
-      CPU_SET(cpu_id, &cpu_set); // Add this CPU to the set
-    }
-  }
-
-  assert(sched_setaffinity(0, sizeof(cpu_set_t), &cpu_set) == 0);
-}

--- a/csrc/common/util.hpp
+++ b/csrc/common/util.hpp
@@ -1,6 +1,9 @@
 #pragma once
 
 #include <cassert>
+#include <vector>
+#include <algorithm>
+#include <sched.h>
 
 #define CHECK_CUDA(call)                                                       \
   do {                                                                         \
@@ -55,3 +58,32 @@
       assert(false);                                                           \
     }                                                                          \
   } while (0)
+
+void set_affinity(const std::vector<int>& excluded_cpus = {}) {
+  cpu_set_t cpu_set;
+  CPU_ZERO(&cpu_set);
+
+  for (int i = 0; i < CPU_SETSIZE; ++i) {
+    if (std::find(excluded_cpus.begin(), excluded_cpus.end(), i) == excluded_cpus.end()) {
+      CPU_SET(i, &cpu_set);
+    }
+  }
+
+  assert(sched_setaffinity(0, sizeof(cpu_set_t), &cpu_set) == 0);
+}
+
+std::vector<int> get_affinity() {
+  std::vector<int> cpu_affinity;
+
+  cpu_set_t cpu_set;
+  CPU_ZERO(&cpu_set);
+  assert(sched_getaffinity(0, sizeof(cpu_set_t), &cpu_set) == 0);
+
+  for (int i = 0; i < CPU_SETSIZE; ++i) {
+    if (CPU_ISSET(i, &cpu_set)) {
+      cpu_affinity.push_back(i);
+    }
+  }
+
+  return cpu_affinity;
+}

--- a/csrc/spiral_cpu_adam/cpu_adam.cpp
+++ b/csrc/spiral_cpu_adam/cpu_adam.cpp
@@ -31,15 +31,17 @@ struct ThreadSafeOptimizer {
   std::mutex m;
   std::vector<std::shared_ptr<torch::Tensor>> fp32_param_list;
   std::vector<float> found_inf_list;
+  std::vector<int> excluded_cpus;
 
   ThreadSafeOptimizer(
       std::unordered_map<int, std::shared_ptr<void>> group_s_opts,
       const int nparams,
       const int pool_size,
       const bool half_precision,
-      const bool should_log)
+      const bool should_log,
+      const std::vector<int>& excluded_cpus)
     : group_s_opts(group_s_opts), pool(pool_size), nparams(nparams),
-      nparams_submitted(0), should_log(should_log)
+      nparams_submitted(0), should_log(should_log), excluded_cpus(excluded_cpus)
   {
     if (half_precision)
       fp32_param_list.resize(nparams);
@@ -79,8 +81,9 @@ int spiral_create_adam_optimizer(int optimizer_id,
   else if (pool_size < 0)
     throw std::runtime_error("Invalid thread pool size");
 
+  std::vector<int> excluded_cpus = get_affinity();
   s_optimizers[optimizer_id] = std::make_shared<ThreadSafeOptimizer>(
-      group_s_opts, nparams, pool_size, half_precision, should_log);
+      group_s_opts, nparams, pool_size, half_precision, should_log, excluded_cpus);
 
   if (should_log) {
     printf("[%ld] ThreadSafeOptimizer #%d is created with %d threads for %d "
@@ -145,6 +148,9 @@ int _spiral_adam_step(int optimizer_id,
 {
   auto ts_opt =
       std::static_pointer_cast<ThreadSafeOptimizer>(s_optimizers[optimizer_id]);
+  
+  // Set thread cpu affinity to not use the main thread cpu
+  set_affinity(ts_opt->excluded_cpus);
 
   if (ev_long == 0) {
     throw std::runtime_error("Event is not recorded");

--- a/csrc/spiral_cpu_adam/cpu_adam.cpp
+++ b/csrc/spiral_cpu_adam/cpu_adam.cpp
@@ -31,7 +31,7 @@ struct ThreadSafeOptimizer {
   std::mutex m;
   std::vector<std::shared_ptr<torch::Tensor>> fp32_param_list;
   std::vector<float> found_inf_list;
-  std::vector<int> excluded_cpus;
+  std::vector<int> cpu_affinity;
 
   ThreadSafeOptimizer(
       std::unordered_map<int, std::shared_ptr<void>> group_s_opts,
@@ -39,9 +39,9 @@ struct ThreadSafeOptimizer {
       const int pool_size,
       const bool half_precision,
       const bool should_log,
-      const std::vector<int>& excluded_cpus)
+      const std::vector<int>& cpu_affinity)
     : group_s_opts(group_s_opts), pool(pool_size), nparams(nparams),
-      nparams_submitted(0), should_log(should_log), excluded_cpus(excluded_cpus)
+      nparams_submitted(0), should_log(should_log), cpu_affinity(cpu_affinity)
   {
     if (half_precision)
       fp32_param_list.resize(nparams);
@@ -63,7 +63,7 @@ int spiral_create_adam_optimizer(int optimizer_id,
                                  float weight_decay,
                                  bool adamw_mode,
                                  bool should_log,
-                                 std::vector<int> excluded_cpus)
+                                 std::vector<int> cpu_affinity)
 {
   /*
    * Each backward stage has a ThreadSafeOptimizer and a ThreadPool.
@@ -82,12 +82,8 @@ int spiral_create_adam_optimizer(int optimizer_id,
   else if (pool_size < 0)
     throw std::runtime_error("Invalid thread pool size");
 
-  if (excluded_cpus.empty()) {
-    // If excludede_cpus is not set, assign the CPU affinity of the main thread
-    excluded_cpus = get_affinity();
-  }
   s_optimizers[optimizer_id] = std::make_shared<ThreadSafeOptimizer>(
-      group_s_opts, nparams, pool_size, half_precision, should_log, excluded_cpus);
+      group_s_opts, nparams, pool_size, half_precision, should_log, cpu_affinity);
 
   if (should_log) {
     printf("[%ld] ThreadSafeOptimizer #%d is created with %d threads for %d "
@@ -154,7 +150,7 @@ int _spiral_adam_step(int optimizer_id,
       std::static_pointer_cast<ThreadSafeOptimizer>(s_optimizers[optimizer_id]);
   
   // Set thread cpu affinity to not use the main thread cpu
-  set_affinity(ts_opt->excluded_cpus);
+  set_cpu_affinity(ts_opt->cpu_affinity);
 
   if (ev_long == 0) {
     throw std::runtime_error("Event is not recorded");

--- a/csrc/spiral_cpu_adam/cpu_adam.cpp
+++ b/csrc/spiral_cpu_adam/cpu_adam.cpp
@@ -15,9 +15,28 @@
 #include <mutex>
 #include <thread>
 #include <unistd.h>
+#include <sched.h>
 #include <nvToolsExt.h>
 
 #define _DEBUG_OPTIMIZER false // for debugging Tensor values
+
+void set_cpu_affinity(const std::vector<int> &cpu_affinity = {})
+{
+  // By default, assign the CPU affinity of the main thread
+  if (cpu_affinity.empty()){
+    return;
+  }
+
+  cpu_set_t cpu_set;
+  CPU_ZERO(&cpu_set);
+  for (int cpu_id : cpu_affinity){
+    if (cpu_id >= 0 && cpu_id < CPU_SETSIZE) {
+      CPU_SET(cpu_id, &cpu_set); // Add this CPU to the set
+    }
+  }
+
+  assert(sched_setaffinity(0, sizeof(cpu_set_t), &cpu_set) == 0);
+}
 
 struct ThreadSafeOptimizer {
   std::unordered_map<int, std::shared_ptr<void>>
@@ -310,6 +329,8 @@ int _spiral_adam_rollback(int optimizer_id,
 {
   auto ts_opt =
       std::static_pointer_cast<ThreadSafeOptimizer>(s_optimizers[optimizer_id]);
+
+  set_cpu_affinity(ts_opt->cpu_affinity);
 
   if (ev_long == 0) {
     throw std::runtime_error("Event is not recorded");

--- a/csrc/spiral_cpu_adam/cpu_adam.cpp
+++ b/csrc/spiral_cpu_adam/cpu_adam.cpp
@@ -62,7 +62,8 @@ int spiral_create_adam_optimizer(int optimizer_id,
                                  float eps,
                                  float weight_decay,
                                  bool adamw_mode,
-                                 bool should_log)
+                                 bool should_log,
+                                 std::vector<int> excluded_cpus)
 {
   /*
    * Each backward stage has a ThreadSafeOptimizer and a ThreadPool.
@@ -81,7 +82,10 @@ int spiral_create_adam_optimizer(int optimizer_id,
   else if (pool_size < 0)
     throw std::runtime_error("Invalid thread pool size");
 
-  std::vector<int> excluded_cpus = get_affinity();
+  if (excluded_cpus.empty()) {
+    // If excludede_cpus is not set, assign the CPU affinity of the main thread
+    excluded_cpus = get_affinity();
+  }
   s_optimizers[optimizer_id] = std::make_shared<ThreadSafeOptimizer>(
       group_s_opts, nparams, pool_size, half_precision, should_log, excluded_cpus);
 

--- a/csrc/spiral_helper/comm.cpp
+++ b/csrc/spiral_helper/comm.cpp
@@ -9,6 +9,7 @@
 #include <list>
 #include <memory>
 #include <mpi.h>
+#include <numa.h>
 #include <nvToolsExt.h>
 #include <pybind11/numpy.h>
 #include <semaphore.h>
@@ -175,7 +176,8 @@ public:
        const char* shared_memory_name,
        const size_t kCpuBufferSize,
        const size_t kCpuBufferHeaderSize,
-       const size_t alignment);
+       const size_t alignment,
+       const int cpu_id);
   Comm(const Comm&) = delete;            // copy ctor
   Comm(Comm&&) = delete;                 // move ctor
   Comm& operator=(const Comm&) = delete; // copy assign
@@ -268,7 +270,8 @@ Comm::Comm(std::vector<int> ranks,
            const char* shared_memory_name,
            const size_t kCpuBufferSize,
            const size_t kCpuBufferHeaderSize,
-           const size_t alignment)
+           const size_t alignment,
+           const int cpu_id)
 {
   if (Comm::debug)
     spdlog::info("Creating SpiralPipe Comm");
@@ -379,6 +382,18 @@ Comm::Comm(std::vector<int> ranks,
   assert(kCpuBufferHeaderSize % comm_info_.mpi_size_ == 0);
   if (comm_info_.intra_rank_ == 0) {
     memset(param_mapping_tbl_, 0, kCpuBufferHeaderSize);
+  }
+
+  // Set NUMA
+  if (Comm::debug)
+    spdlog::info("NUMA node ID = {}", numa_node_of_cpu(cpu_id));
+  numa_tonode_memory((void*)GetBase(comm_info_.mpi_rank_), kCpuBufferSize / comm_info_.intra_size_, numa_node_of_cpu(cpu_id));
+
+  // Check NUMA
+  {
+    int mode;
+    assert(get_mempolicy(&mode, NULL, 0, GetBase(comm_info_.mpi_rank_), MPOL_F_NODE | MPOL_F_ADDR) == 0);
+    assert(mode == numaIdx);
   }
 
   // Initialize allocator
@@ -745,7 +760,7 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m)
         "SpiralPipeBackend LazyConfigure (C++)");
   py::class_<Comm>(m, "Comm")
       .def(py::init<std::vector<int>, const int, const bool, const char*,
-                    const size_t, const size_t, const size_t>())
+                    const size_t, const size_t, const size_t, const int>())
       .def("SetSpiralCPUAllocator", &Comm::SetSpiralCPUAllocator)
       .def("UnsetSpiralCPUAllocator", &Comm::UnsetSpiralCPUAllocator)
       .def("RemapLocalParamData", &Comm::RemapLocalParamData)

--- a/csrc/spiral_helper/setup.py
+++ b/csrc/spiral_helper/setup.py
@@ -23,7 +23,7 @@ setup(
                 os.path.join(os.environ['MPI_BUILD_DIR'], 'lib'),
                 os.path.join(os.environ['CUDA_BUILD_DIR'], 'lib64'),
             ],
-            libraries=['mpi', 'rt', 'pthread', 'cuda', 'cudart', 'nvToolsExt'],
+            libraries=['mpi', 'rt', 'pthread', 'cuda', 'cudart', 'nvToolsExt', 'numa'],
             extra_compile_args=['-g', '-fvisibility=hidden']
         )
     ],

--- a/examples/asplos25/extra_args/spiral.sh
+++ b/examples/asplos25/extra_args/spiral.sh
@@ -10,7 +10,7 @@ EXTRA_ARGS="
     --spiral-backward-virtual-size $SPIRAL_BWD \
     --spiral-overlap-offload-grad \
     --spiral-recompute-activations \
-    --spiral-ckpt-comm-threshold 2 \
+    --spiral-ckpt-comm-threshold 3 \
     --overlap-p2p-communication \
     --megatron-mpi
 "

--- a/examples/asplos25/models/llama2.sh
+++ b/examples/asplos25/models/llama2.sh
@@ -4,8 +4,8 @@
 if [ $MODEL_SIZE -eq 1 ]; then
     # 1.3B
     LAYER=24
-    HIDDEN=1024
-    FFN_HIDDEN=3072
+    HIDDEN=2048
+    FFN_HIDDEN=5504
     HEAD=16
     NUM_KV_HEADS=16
 elif [ $MODEL_SIZE -eq 7 ]; then

--- a/examples/asplos25/run.sh
+++ b/examples/asplos25/run.sh
@@ -5,6 +5,7 @@
 #SBATCH --mem=0
 #SBATCH --exclusive
 #SBATCH --gres=gpu:4
+#SBATCH --output=slurm-%j-%x.out
 
 ulimit -v unlimited
 
@@ -53,10 +54,17 @@ fi
 EXEC_CMD="python ${MEGATRON_PATH}/pretrain_gpt.py ${EXTRA_ARGS} ${DISTRIBUTED_ARGS} ${MODEL_ARGS} ${DATA_ARGS} ${MIXED_PRECISION_ARGS} ${LOGGING_ARGS}"
 
 if [ ${NSYS_ENABLE} == "YES" ]; then
-    EXEC_CMD="${NSYS} profile -t cuda,nvtx -o ${NSYS_OUTPUT}_%q{OMPI_COMM_WORLD_RANK} --force-overwrite true ${EXEC_CMD}"
+    EXEC_CMD="${NSYS} profile -t cuda,nvtx -o ${NSYS_OUTPUT}_\$OMPI_COMM_WORLD_RANK --force-overwrite true ${EXEC_CMD}"
 fi
 
+# Configure numactl
+EXEC_CMD="numactl --cpunodebind \$OMPI_COMM_WORLD_LOCAL_RANK --membind \$OMPI_COMM_WORLD_LOCAL_RANK ${EXEC_CMD}"
+
+# Remove newline
+EXEC_CMD=$(echo "$EXEC_CMD" | tr '\n' ' ')
+
 # Run script
-${MPIRUN} --bind-to none --report-bindings -npernode $GPUS_PER_NODE -host $HOSTS $MPI_OPTIONS ${EXEC_CMD}
+mpirun --bind-to none --report-bindings -npernode $GPUS_PER_NODE -host $HOSTS $MPI_OPTIONS -x OMP_NUM_THREADS=8 \
+    bash -c "${EXEC_CMD}"
 
 exit 0

--- a/examples/asplos25/run.sh
+++ b/examples/asplos25/run.sh
@@ -58,7 +58,7 @@ if [ ${NSYS_ENABLE} == "YES" ]; then
 fi
 
 # Configure numactl
-EXEC_CMD="numactl --cpunodebind \$OMPI_COMM_WORLD_LOCAL_RANK --membind \$OMPI_COMM_WORLD_LOCAL_RANK ${EXEC_CMD}"
+EXEC_CMD="numactl --cpunodebind \$((3 - \$OMPI_COMM_WORLD_LOCAL_RANK)) --membind \$((3 - \$OMPI_COMM_WORLD_LOCAL_RANK)) ${EXEC_CMD}"
 
 # Remove newline
 EXEC_CMD=$(echo "$EXEC_CMD" | tr '\n' ' ')

--- a/megatron/initialize.py
+++ b/megatron/initialize.py
@@ -20,7 +20,7 @@ from megatron.checkpointing import load_args_from_checkpoint
 from megatron.global_vars import set_global_variables
 from megatron.model.transformer import bias_dropout_add_fused_train
 from megatron.model.fused_bias_gelu import bias_gelu
-from megatron.spiral import SpiralBackend, get_thunder_group
+from megatron.spiral import SpiralBackend, get_thunder_group, set_node_cpu_affinity
 import megatron.spiral.build_state as sbs
 from megatron.spiral.debug import spiral_print
 import spiral_helper
@@ -398,6 +398,7 @@ def _spiral_backend_init():
             2 if (args.fp16 or args.bf16) else 4,
         )
         _set_comm_info()
+        set_node_cpu_affinity()
 
 
 def _spiral_build_state_init():

--- a/megatron/initialize.py
+++ b/megatron/initialize.py
@@ -20,7 +20,7 @@ from megatron.checkpointing import load_args_from_checkpoint
 from megatron.global_vars import set_global_variables
 from megatron.model.transformer import bias_dropout_add_fused_train
 from megatron.model.fused_bias_gelu import bias_gelu
-from megatron.spiral import SpiralBackend, get_thunder_group, set_node_cpu_affinity
+from megatron.spiral import SpiralBackend, get_thunder_group, set_cpu_affinity
 import megatron.spiral.build_state as sbs
 from megatron.spiral.debug import spiral_print
 import spiral_helper
@@ -398,7 +398,7 @@ def _spiral_backend_init():
             2 if (args.fp16 or args.bf16) else 4,
         )
         _set_comm_info()
-        set_node_cpu_affinity()
+        set_cpu_affinity()
 
 
 def _spiral_build_state_init():

--- a/megatron/spiral/__init__.py
+++ b/megatron/spiral/__init__.py
@@ -2,6 +2,8 @@ from .initialize import (
     SpiralBackend,
     get_thunder_group,
     get_thunder_cuda_manager,
+    get_node_cpu_affinity,
+    set_node_cpu_affinity,
 )
 from .init_context import SpiralInitContext, SpiralParamStatus
 from .wrapper_init_context import SpiralWrapperInitContext

--- a/megatron/spiral/__init__.py
+++ b/megatron/spiral/__init__.py
@@ -2,8 +2,8 @@ from .initialize import (
     SpiralBackend,
     get_thunder_group,
     get_thunder_cuda_manager,
-    get_node_cpu_affinity,
-    set_node_cpu_affinity,
+    get_available_cpu_affinity,
+    set_cpu_affinity,
 )
 from .init_context import SpiralInitContext, SpiralParamStatus
 from .wrapper_init_context import SpiralWrapperInitContext

--- a/megatron/spiral/initialize.py
+++ b/megatron/spiral/initialize.py
@@ -2,8 +2,12 @@ from typing import Optional, Union, Tuple
 from collections import deque
 from dataclasses import dataclass
 import atexit
+import os
+import psutil
 
 import torch
+
+from megatron.core import mpu
 
 import spiral_helper
 
@@ -53,6 +57,28 @@ def get_thunder_cuda_manager():
     global SPIRAL_BACKEND
     assert SPIRAL_BACKEND is not None, "SpiralBackend is not initialized"
     return SPIRAL_BACKEND.thunder_cuda_manager
+
+
+def get_node_cpu_affinity():
+    global SPIRAL_BACKEND
+    assert SPIRAL_BACKEND is not None, "SpiralBackend is not initialized"
+    return SPIRAL_BACKEND.node_cpu_affinity
+
+
+def set_node_cpu_affinity():
+    """Share CPU affinity only with ranks on the same node."""
+    node_group = torch.distributed.new_group(mpu.get_spiral_local_ranks())
+    os.sched_setaffinity(0, {psutil.Process().cpu_num()}) # set current process affinity to current cpu
+    affinity = os.sched_getaffinity(0)
+    node_affinity = torch.tensor(
+        [1 if i in affinity else 0 for i in range(os.cpu_count())],
+        dtype=torch.int32,
+        device="cuda",
+    )
+    torch.distributed.all_reduce(node_affinity, op=torch.distributed.ReduceOp.SUM, group=node_group)
+    assert torch.sum(node_affinity) == torch.distributed.get_world_size(group=node_group)
+    assert torch.max(node_affinity) == 1, "CPU affinity conflict between ranks on the same node"
+    SPIRAL_BACKEND.node_cpu_affinity = node_affinity.tolist()
 
 
 @dataclass(frozen=True)

--- a/megatron/spiral/initialize.py
+++ b/megatron/spiral/initialize.py
@@ -31,6 +31,7 @@ class SpiralBackend:
             shared_memory_buffer_size,
             shared_memory_header_size,
             alignment,
+            psutil.Process().cpu_num(),
         )
         self.thunder_cuda_manager = SpiralCUDAManager()
         global SPIRAL_BACKEND

--- a/megatron/spiral/initialize.py
+++ b/megatron/spiral/initialize.py
@@ -7,8 +7,6 @@ import psutil
 
 import torch
 
-from megatron.core import mpu
-
 import spiral_helper
 
 SPIRAL_BACKEND = None

--- a/megatron/spiral/initialize.py
+++ b/megatron/spiral/initialize.py
@@ -9,6 +9,8 @@ import torch
 
 import spiral_helper
 
+from megatron.spiral.debug import spiral_print
+
 SPIRAL_BACKEND = None
 
 
@@ -68,6 +70,7 @@ def set_cpu_affinity():
     cpu_affinity = psutil.Process().cpu_affinity()
     curr_cpu_num = psutil.Process().cpu_num()
     os.sched_setaffinity(0, {curr_cpu_num}) # set current process affinity to current cpu
+    spiral_print(f"pt_main_thread cpu core id = {curr_cpu_num}")
     cpu_affinity.remove(curr_cpu_num)
     SPIRAL_BACKEND.available_cpu_affinity = cpu_affinity
 

--- a/megatron/spiral/initialize.py
+++ b/megatron/spiral/initialize.py
@@ -59,26 +59,18 @@ def get_thunder_cuda_manager():
     return SPIRAL_BACKEND.thunder_cuda_manager
 
 
-def get_node_cpu_affinity():
+def get_available_cpu_affinity():
     global SPIRAL_BACKEND
     assert SPIRAL_BACKEND is not None, "SpiralBackend is not initialized"
-    return SPIRAL_BACKEND.node_cpu_affinity
+    return SPIRAL_BACKEND.available_cpu_affinity
 
 
-def set_node_cpu_affinity():
-    """Share CPU affinity only with ranks on the same node."""
-    node_group = torch.distributed.new_group(mpu.get_spiral_local_ranks())
-    os.sched_setaffinity(0, {psutil.Process().cpu_num()}) # set current process affinity to current cpu
-    affinity = os.sched_getaffinity(0)
-    node_affinity = torch.tensor(
-        [1 if i in affinity else 0 for i in range(os.cpu_count())],
-        dtype=torch.int32,
-        device="cuda",
-    )
-    torch.distributed.all_reduce(node_affinity, op=torch.distributed.ReduceOp.SUM, group=node_group)
-    assert torch.sum(node_affinity) == torch.distributed.get_world_size(group=node_group)
-    assert torch.max(node_affinity) == 1, "CPU affinity conflict between ranks on the same node"
-    SPIRAL_BACKEND.node_cpu_affinity = node_affinity.tolist()
+def set_cpu_affinity():
+    cpu_affinity = psutil.Process().cpu_affinity()
+    curr_cpu_num = psutil.Process().cpu_num()
+    os.sched_setaffinity(0, {curr_cpu_num}) # set current process affinity to current cpu
+    cpu_affinity.remove(curr_cpu_num)
+    SPIRAL_BACKEND.available_cpu_affinity = cpu_affinity
 
 
 @dataclass(frozen=True)

--- a/megatron/spiral/optimizer/cpu_adam.py
+++ b/megatron/spiral/optimizer/cpu_adam.py
@@ -4,7 +4,7 @@ from megatron import get_args
 
 from deepspeed.utils import logger
 from deepspeed.utils.logging import should_log_le
-from megatron.spiral import get_node_cpu_affinity
+from megatron.spiral import get_available_cpu_affinity
 
 from .cpu_adam_builder import SpiralCPUAdamBuilder
 
@@ -128,7 +128,7 @@ class SpiralCPUAdam(torch.optim.Optimizer):
             weight_decay,
             adamw_mode,
             should_log_le("info"),
-            get_node_cpu_affinity()
+            get_available_cpu_affinity()
         )
         self.inv_scale = 0
         self.ev_long = -1

--- a/megatron/spiral/optimizer/cpu_adam.py
+++ b/megatron/spiral/optimizer/cpu_adam.py
@@ -4,6 +4,7 @@ from megatron import get_args
 
 from deepspeed.utils import logger
 from deepspeed.utils.logging import should_log_le
+from megatron.spiral import get_node_cpu_affinity
 
 from .cpu_adam_builder import SpiralCPUAdamBuilder
 
@@ -127,6 +128,7 @@ class SpiralCPUAdam(torch.optim.Optimizer):
             weight_decay,
             adamw_mode,
             should_log_le("info"),
+            get_node_cpu_affinity()
         )
         self.inv_scale = 0
         self.ev_long = -1


### PR DESCRIPTION
**Set OMP_NUM_THREAHDS**
In CPUAdam, omp_num_thread was set to 1.
Set `OMP_NUM_THREADS=8` as env variable and bind numa node to process.

**Bind NUMA node to process**
Assgin NUMA node as `$((3 - $OMPI_COMM_WORLD_LOCAL_RANK))` which is match with our experiment node (erc v100)

**Shmem alloc to each numa node memory**
When initialize shmem in spiral_helper, each part of shmem is assigned to process's numa node memory

**Set affinity to pt_main_thread**
Set cpu affinity separately so that pt_main_thread is not affected by cpu_adam

(+) update LLaMA 1.3B config and default `--spiral-ckpt-comm-threshold` as 3