### PR TITLE
Log GPU pipeline latency

### DIFF
--- a/megatron/arguments.py
+++ b/megatron/arguments.py
@@ -1158,6 +1158,9 @@ def _add_distributed_args(parser):
                         help='Enable SpiralPipe p2p checkpoint communication')
     group.add_argument('--spiral-ckpt-comm-threshold', type=int, default=1,
                         help='Number of separate checkpoint communication communicators')
+    group.add_argument('--spiral-log-gpu-pipeline-latency', action='store_true',
+                        help='Log GPU pipeline latency. Measure elapsed time from first prefetch to last offload. '
+                        'This is incompatible with hetero or chunked optimizer, or without overlap offload grad')
     return parser
 
 

--- a/megatron/arguments.py
+++ b/megatron/arguments.py
@@ -1160,7 +1160,7 @@ def _add_distributed_args(parser):
                         help='Number of separate checkpoint communication communicators')
     group.add_argument('--spiral-log-gpu-pipeline-latency', action='store_true',
                         help='Log GPU pipeline latency. Measure elapsed time from first prefetch to last offload. '
-                        'This is incompatible with hetero or chunked optimizer, or without overlap offload grad')
+                        'This is incompatible with stage, hetero, or chunked optimizer, or without overlap offload grad')
     return parser
 
 

--- a/megatron/spiral/schedules/mobius_schedule.py
+++ b/megatron/spiral/schedules/mobius_schedule.py
@@ -641,10 +641,8 @@ def mobius_schedule(
 
     # end GPU latency timer
     if log_gpu_pipeline_latency:
-        torch.cuda.synchronize()
         backward_pass_end_event.record()
-        forward_pass_start_event.synchronize()
-        backward_pass_end_event.synchronize()
+        torch.cuda.synchronize()
         get_gpu_latency_list().append(forward_pass_start_event.elapsed_time(backward_pass_end_event))
 
     return forward_data_store

--- a/megatron/spiral/schedules/mobius_schedule.py
+++ b/megatron/spiral/schedules/mobius_schedule.py
@@ -641,9 +641,8 @@ def mobius_schedule(
 
     # end GPU latency timer
     if log_gpu_pipeline_latency:
+        torch.cuda.synchronize()
         backward_pass_end_event.record()
-
-    if log_gpu_pipeline_latency:
         forward_pass_start_event.synchronize()
         backward_pass_end_event.synchronize()
         get_gpu_latency_list().append(forward_pass_start_event.elapsed_time(backward_pass_end_event))

--- a/megatron/spiral/schedules/mobius_schedule.py
+++ b/megatron/spiral/schedules/mobius_schedule.py
@@ -15,6 +15,7 @@ from megatron.spiral.initialize import get_thunder_cuda_manager
 from megatron.spiral.debug import spiral_print
 from megatron.spiral.init_context import SpiralParamStatus, set_module_spiral_status
 from megatron.spiral.generic import ContextManagers
+from megatron.spiral.utils import get_gpu_latency_list
 
 from .mobius_communication import (
     comm_activation,
@@ -178,7 +179,17 @@ def mobius_schedule(
     # Placeholders
     recv_reqs: List[Work] = []
 
+    # GPU latency event
+    log_gpu_pipeline_latency = get_args().spiral_log_gpu_pipeline_latency
+    if log_gpu_pipeline_latency:
+        forward_pass_start_event = torch.cuda.Event(enable_timing=True)
+        backward_pass_end_event = torch.cuda.Event(enable_timing=True)
+
     """ Start training """
+
+    # start GPU latency timer
+    if log_gpu_pipeline_latency:
+        forward_pass_start_event.record()
 
     # prefetch 1st fwd stage
     with torch.cuda.stream(get_thunder_cuda_manager().Stream("prefetch")):
@@ -627,4 +638,14 @@ def mobius_schedule(
                         raise RuntimeError("wait_event failed")
 
     _cleanup()
+
+    # end GPU latency timer
+    if log_gpu_pipeline_latency:
+        backward_pass_end_event.record()
+
+    if log_gpu_pipeline_latency:
+        forward_pass_start_event.synchronize()
+        backward_pass_end_event.synchronize()
+        get_gpu_latency_list().append(forward_pass_start_event.elapsed_time(backward_pass_end_event))
+
     return forward_data_store

--- a/megatron/spiral/schedules/onefoneb_schedule.py
+++ b/megatron/spiral/schedules/onefoneb_schedule.py
@@ -841,9 +841,8 @@ def onefoneb_schedule(
 
     # end GPU latency timer
     if log_gpu_pipeline_latency:
+        torch.cuda.synchronize()
         backward_pass_end_event.record()
-
-    if log_gpu_pipeline_latency:
         forward_pass_start_event.synchronize()
         backward_pass_end_event.synchronize()
         get_gpu_latency_list().append(forward_pass_start_event.elapsed_time(backward_pass_end_event))

--- a/megatron/spiral/schedules/onefoneb_schedule.py
+++ b/megatron/spiral/schedules/onefoneb_schedule.py
@@ -841,10 +841,8 @@ def onefoneb_schedule(
 
     # end GPU latency timer
     if log_gpu_pipeline_latency:
-        torch.cuda.synchronize()
         backward_pass_end_event.record()
-        forward_pass_start_event.synchronize()
-        backward_pass_end_event.synchronize()
+        torch.cuda.synchronize()
         get_gpu_latency_list().append(forward_pass_start_event.elapsed_time(backward_pass_end_event))
 
     return forward_data_store

--- a/megatron/spiral/schedules/onefoneb_schedule.py
+++ b/megatron/spiral/schedules/onefoneb_schedule.py
@@ -12,6 +12,7 @@ from megatron.core.pipeline_parallel import forward_step, backward_step, p2p_com
 from megatron.spiral.initialize import get_thunder_cuda_manager
 from megatron.spiral.debug import spiral_print
 from megatron.spiral.init_context import SpiralParamStatus, set_module_spiral_status
+from megatron.spiral.utils import get_gpu_latency_list
 
 
 class PHASE(Enum):
@@ -98,6 +99,12 @@ def onefoneb_schedule(
     output_tensor = None
     fwd_wait_handles = None
     bwd_wait_handles = None
+
+    # GPU latency event
+    log_gpu_pipeline_latency = get_args().spiral_log_gpu_pipeline_latency
+    if log_gpu_pipeline_latency:
+        forward_pass_start_event = torch.cuda.Event(enable_timing=True)
+        backward_pass_end_event = torch.cuda.Event(enable_timing=True)
 
     """Offload grads and optimizer related"""
     offload_grad_after_bwd_stage = get_args().spiral_overlap_offload_grad
@@ -691,6 +698,10 @@ def onefoneb_schedule(
     """ Start training """
     ####################################################################################################
 
+    # start GPU latency timer
+    if log_gpu_pipeline_latency:
+        forward_pass_start_event.record()
+
     # prefetch 1st fwd stage
     with torch.cuda.stream(get_thunder_cuda_manager().Stream("prefetch")):
         if _DEBUG_SCHEDULE:
@@ -707,6 +718,10 @@ def onefoneb_schedule(
         if get_thunder_cuda_manager().record_event(prefetch_f0) == -1:
             raise RuntimeError("record_event failed")
         prefetch_events.append(prefetch_f0)
+
+        # start GPU latency timer
+        if log_gpu_pipeline_latency:
+            forward_pass_start_event.record()
 
     ##### warmup
     _PHASE = PHASE.WARMUP
@@ -823,4 +838,14 @@ def onefoneb_schedule(
             raise RuntimeError("wait_event failed")
 
     _cleanup()
+
+    # end GPU latency timer
+    if log_gpu_pipeline_latency:
+        backward_pass_end_event.record()
+
+    if log_gpu_pipeline_latency:
+        forward_pass_start_event.synchronize()
+        backward_pass_end_event.synchronize()
+        get_gpu_latency_list().append(forward_pass_start_event.elapsed_time(backward_pass_end_event))
+
     return forward_data_store

--- a/megatron/spiral/schedules/spipe_schedule.py
+++ b/megatron/spiral/schedules/spipe_schedule.py
@@ -697,9 +697,8 @@ def spipe_schedule(
 
     # end GPU latency timer
     if log_gpu_pipeline_latency:
+        torch.cuda.synchronize()
         backward_pass_end_event.record()
-
-    if log_gpu_pipeline_latency:
         forward_pass_start_event.synchronize()
         backward_pass_end_event.synchronize()
         get_gpu_latency_list().append(forward_pass_start_event.elapsed_time(backward_pass_end_event))

--- a/megatron/spiral/schedules/spipe_schedule.py
+++ b/megatron/spiral/schedules/spipe_schedule.py
@@ -14,6 +14,7 @@ from megatron.core.pipeline_parallel import forward_step, backward_step
 from megatron.spiral.initialize import get_thunder_cuda_manager
 from megatron.spiral.debug import spiral_print
 from megatron.spiral.init_context import SpiralParamStatus, set_module_spiral_status
+from megatron.spiral.utils import get_gpu_latency_list
 
 from .spipe_ckpt_communication import comm_ckpt
 from .spipe_ckpt_schedule import CkptSendRecvSchedule
@@ -173,7 +174,17 @@ def spipe_schedule(
     recv_reqs: List[Work] = []
     ckpt_recv_reqs: List[Work] = []
 
+    # GPU latency event
+    log_gpu_pipeline_latency = get_args().spiral_log_gpu_pipeline_latency
+    if log_gpu_pipeline_latency:
+        forward_pass_start_event = torch.cuda.Event(enable_timing=True)
+        backward_pass_end_event = torch.cuda.Event(enable_timing=True)
+
     """ Start training """
+
+    # start GPU latency timer
+    if log_gpu_pipeline_latency:
+        forward_pass_start_event.record()
 
     # prefetch 1st fwd stage
     with torch.cuda.stream(get_thunder_cuda_manager().Stream("prefetch")):
@@ -683,4 +694,14 @@ def spipe_schedule(
                         raise RuntimeError("wait_event failed")
 
     _cleanup()
+
+    # end GPU latency timer
+    if log_gpu_pipeline_latency:
+        backward_pass_end_event.record()
+
+    if log_gpu_pipeline_latency:
+        forward_pass_start_event.synchronize()
+        backward_pass_end_event.synchronize()
+        get_gpu_latency_list().append(forward_pass_start_event.elapsed_time(backward_pass_end_event))
+
     return forward_data_store

--- a/megatron/spiral/schedules/spipe_schedule.py
+++ b/megatron/spiral/schedules/spipe_schedule.py
@@ -697,10 +697,8 @@ def spipe_schedule(
 
     # end GPU latency timer
     if log_gpu_pipeline_latency:
-        torch.cuda.synchronize()
         backward_pass_end_event.record()
-        forward_pass_start_event.synchronize()
-        backward_pass_end_event.synchronize()
+        torch.cuda.synchronize()
         get_gpu_latency_list().append(forward_pass_start_event.elapsed_time(backward_pass_end_event))
 
     return forward_data_store

--- a/megatron/spiral/utils.py
+++ b/megatron/spiral/utils.py
@@ -3,7 +3,6 @@ from functools import reduce
 
 import torch
 
-
 def is_spiral_param(param):
     if not torch.is_tensor(param):
         return False
@@ -25,3 +24,35 @@ except ImportError:
         assert len(args) > 0, "lcm() requires at least one argument"
         assert len(args) < 3, "For Python < 3.9, math.gcd() currently only supports upto two arguments"
         return abs(reduce(lambda acc, cur: acc * cur, args, 1) // math.gcd(*args))
+
+_GPU_LATENCY_LIST = None
+
+class DummyMaxList:
+    def __init__(self):
+        self._list = []
+
+    def append(self, item):
+        from megatron.core import mpu
+        max_lat = torch.tensor(item, device="cuda")
+        torch.distributed.all_reduce(max_lat, group=mpu.get_pipeline_model_parallel_group(), op=torch.distributed.ReduceOp.MAX)
+        max_lat = max_lat.item()
+        self._list.append(max_lat)
+
+    def clear(self):
+        self._list.clear()
+
+    def get_avg(self):
+        # print(f"averaging... {self._list}")
+        return sum(self._list) / len(self._list) if self._list else None
+
+
+def create_gpu_latency_list():
+    global _GPU_LATENCY_LIST
+    if _GPU_LATENCY_LIST is None:
+        _GPU_LATENCY_LIST = DummyMaxList()
+
+
+def get_gpu_latency_list():
+    global _GPU_LATENCY_LIST
+    assert _GPU_LATENCY_LIST is not None, "GPU latency list not created"
+    return _GPU_LATENCY_LIST

--- a/megatron/training.py
+++ b/megatron/training.py
@@ -1131,15 +1131,6 @@ def training_log(loss_dict, total_loss_dict, learning_rate, iteration,
         else:
             log_string += " elapsed time per iteration (ms): N/A |"
 
-        if throughput:
-            log_string += f" throughput per GPU (TFLOP/s/GPU): {throughput:.2f} |"
-        else:
-            log_string += " throughput per GPU (TFLOP/s/GPU): N/A |"
-
-            if args.log_timers_to_tensorboard:
-                if writer:
-                    writer.add_scalar("throughput", throughput, iteration)
-
         if args.spiral_log_gpu_pipeline_latency:
             __lat = get_gpu_latency_list().get_avg()
             if __lat:
@@ -1148,6 +1139,15 @@ def training_log(loss_dict, total_loss_dict, learning_rate, iteration,
                 log_string += " max GPU pipeline latency (ms): N/A |"
             if not args.no_refresh_btw_log_intervals:
                 get_gpu_latency_list().clear()
+
+        if throughput:
+            log_string += f" throughput per GPU (TFLOP/s/GPU): {throughput:.2f} |"
+        else:
+            log_string += " throughput per GPU (TFLOP/s/GPU): N/A |"
+
+            if args.log_timers_to_tensorboard:
+                if writer:
+                    writer.add_scalar("throughput", throughput, iteration)
 
         log_string += ' learning rate: {:.3E} |'.format(learning_rate)
         log_string += ' global batch size: {:5d} |'.format(batch_size)

--- a/megatron/training.py
+++ b/megatron/training.py
@@ -52,7 +52,7 @@ from megatron.spiral import (
 )
 import megatron.spiral.build_state as sbs
 from megatron.spiral.module import SpiralPhaseList
-from megatron.spiral.utils import is_spiral_param
+from megatron.spiral.utils import is_spiral_param, create_gpu_latency_list, get_gpu_latency_list
 from megatron.spiral.debug import (
     spiral_print,
     debug_param2id_shape_status,
@@ -198,6 +198,9 @@ def pretrain(train_valid_test_dataset_provider,
     timers.log(['model-and-optimizer-setup',
                 'train/valid/test-data-iterators-setup'], barrier=True)
     print_rank_0('training ...')
+
+    if args.spiral_log_gpu_pipeline_latency:
+        create_gpu_latency_list()
 
     iteration = 0
 
@@ -1137,6 +1140,15 @@ def training_log(loss_dict, total_loss_dict, learning_rate, iteration,
                 if writer:
                     writer.add_scalar("throughput", throughput, iteration)
 
+        if args.spiral_log_gpu_pipeline_latency:
+            __lat = get_gpu_latency_list().get_avg()
+            if __lat:
+                log_string += f" max GPU pipeline latency (ms): {__lat:.1f} |"
+            else:
+                log_string += " max GPU pipeline latency (ms): N/A |"
+            if not args.no_refresh_btw_log_intervals:
+                get_gpu_latency_list().clear()
+
         log_string += ' learning rate: {:.3E} |'.format(learning_rate)
         log_string += ' global batch size: {:5d} |'.format(batch_size)
         for key in total_loss_dict:
@@ -1242,6 +1254,8 @@ def train(forward_step_func, model, optimizer, opt_param_scheduler,
             if iteration == 0:
                 timers('interval-time').reset()
                 timers('interval-time').start(barrier=True)
+                if args.spiral_log_gpu_pipeline_latency:
+                    get_gpu_latency_list().clear()
         iteration += 1
         args.consumed_train_samples += mpu.get_data_parallel_world_size() * \
                                        args.micro_batch_size * \


### PR DESCRIPTION
While current elapsed time shows latency of one iteration, pipeline latency accounts for only ~10% of the value.
By giving `--spiral-log-gpu-pipeline-latency`, it logs the elapsed time for the GPU pipeline (which is the whole "schedule" function, wlog). 

The purpose of making this was to log the elapsed time from "the first prefetch -- to the last offload". I need this for evaluating the pipeline latency improvements.
Nevertheless, do not depend too much on it, as it does not care about staged, hetero and chunked optimizer, as well as overlapping gradient offload. 

This aligns with current logging policy. You will get to see something like below:

 iteration       10/      10 | consumed samples:           80 | elapsed time per iteration (ms): 8541.8 | throughput per GPU (TFLOP/s/GPU): 2.03 | **max GPU pipeline latency (ms): 934.1** | learning rate: 1.500E-04 | global batch size:     8 | lm loss: 1.081198E+01 | loss scale: 65536.0 | number of skipped iterations:   0 | number of nan iterations:   0 |